### PR TITLE
RPC Attack/Release

### DIFF
--- a/src/FACT.c
+++ b/src/FACT.c
@@ -2023,7 +2023,7 @@ uint32_t FACTCue_Stop(FACTCue *pCue, uint32_t dwFlags)
 	}
 	FAudio_PlatformLockMutex(pCue->parentBank->parentEngine->apiLock);
 
-	if (pCue->state & FACT_STATE_STOPPED)
+	if (pCue->state & (FACT_STATE_STOPPED | FACT_STATE_STOPPING))
 	{
 		FAudio_PlatformUnlockMutex(
 			pCue->parentBank->parentEngine->apiLock

--- a/src/FACT.c
+++ b/src/FACT.c
@@ -889,7 +889,7 @@ uint32_t FACTSoundBank_Prepare(
 	(*ppCue)->maxRpcReleaseTime = 0;
 	for (i = 0; i < (*ppCue)->sound->trackCount; i += 1)
 	{
-		for(j = 0; j < (*ppCue)->sound->tracks[i].rpcCodeCount; j+=1)
+		for (j = 0; j < (*ppCue)->sound->tracks[i].rpcCodeCount; j += 1)
 		{
 			rpc = FACT_INTERNAL_GetRPC(
 				pSoundBank->parentEngine,

--- a/src/FACT.c
+++ b/src/FACT.c
@@ -822,9 +822,10 @@ uint32_t FACTSoundBank_Prepare(
 	int32_t timeOffset,
 	FACTCue** ppCue
 ) {
-	uint16_t i;
+	uint16_t i, j;
+	float lastX;
+	FACTRPC *rpc;
 	FACTCue *latest;
-	FACTAudioEngine *engine = pSoundBank->parentEngine;
 
 	if (pSoundBank == NULL)
 	{
@@ -886,22 +887,22 @@ uint32_t FACTSoundBank_Prepare(
 
 	/* Calculate Max RPC Release Time */
 	(*ppCue)->maxRpcReleaseTime = 0;
-	for(int i = 0; i < (*ppCue)->sound->trackCount; i += 1)
+	for (i = 0; i < (*ppCue)->sound->trackCount; i += 1)
 	{
-		for(int j = 0; j < (*ppCue)->sound->tracks[i].rpcCodeCount; j+=1)
+		for(j = 0; j < (*ppCue)->sound->tracks[i].rpcCodeCount; j+=1)
 		{
-			FACTRPC *rpc = FACT_INTERNAL_GetRPC(
-				engine,
+			rpc = FACT_INTERNAL_GetRPC(
+				pSoundBank->parentEngine,
 				(*ppCue)->sound->tracks[i].rpcCodes[j]
 			);
-			if (engine->variables[rpc->variable].accessibility & 0x04)
+			if (pSoundBank->parentEngine->variables[rpc->variable].accessibility & 0x04)
 			{
 				if (FAudio_strcmp(
-					engine->variableNames[rpc->variable],
+					pSoundBank->parentEngine->variableNames[rpc->variable],
 					"ReleaseTime"
 				) == 0 && rpc->parameter == RPC_PARAMETER_VOLUME)
 				{
-					float lastX = rpc->points[rpc->pointCount - 1].x;
+					lastX = rpc->points[rpc->pointCount - 1].x;
 					if (lastX > (*ppCue)->maxRpcReleaseTime)
 					{
 						(*ppCue)->maxRpcReleaseTime = lastX;
@@ -2067,8 +2068,8 @@ uint32_t FACTCue_Stop(FACTCue *pCue, uint32_t dwFlags)
 	if (	dwFlags & FACT_FLAG_STOP_IMMEDIATE ||
 		pCue->state & FACT_STATE_PAUSED	||
 		pCue->playingSound == NULL ||
-		(pCue->parentBank->cues[pCue->index].fadeOutMS == 0 &&
-			pCue->maxRpcReleaseTime == 0) 	)
+		(	pCue->parentBank->cues[pCue->index].fadeOutMS == 0 &&
+			pCue->maxRpcReleaseTime == 0	)	)
 	{
 		pCue->start = 0;
 		pCue->elapsed = 0;

--- a/src/FACT.c
+++ b/src/FACT.c
@@ -822,9 +822,7 @@ uint32_t FACTSoundBank_Prepare(
 	int32_t timeOffset,
 	FACTCue** ppCue
 ) {
-	uint16_t i, j;
-	float lastX;
-	FACTRPC *rpc;
+	uint16_t i;
 	FACTCue *latest;
 
 	if (pSoundBank == NULL)
@@ -883,33 +881,6 @@ uint32_t FACTSoundBank_Prepare(
 	{
 		(*ppCue)->variableValues[i] =
 			pSoundBank->parentEngine->variables[i].initialValue;
-	}
-
-	/* Calculate Max RPC Release Time */
-	(*ppCue)->maxRpcReleaseTime = 0;
-	for (i = 0; i < (*ppCue)->sound->trackCount; i += 1)
-	{
-		for (j = 0; j < (*ppCue)->sound->tracks[i].rpcCodeCount; j += 1)
-		{
-			rpc = FACT_INTERNAL_GetRPC(
-				pSoundBank->parentEngine,
-				(*ppCue)->sound->tracks[i].rpcCodes[j]
-			);
-			if (pSoundBank->parentEngine->variables[rpc->variable].accessibility & 0x04)
-			{
-				if (FAudio_strcmp(
-					pSoundBank->parentEngine->variableNames[rpc->variable],
-					"ReleaseTime"
-				) == 0 && rpc->parameter == RPC_PARAMETER_VOLUME)
-				{
-					lastX = rpc->points[rpc->pointCount - 1].x;
-					if (lastX > (*ppCue)->maxRpcReleaseTime)
-					{
-						(*ppCue)->maxRpcReleaseTime = lastX;
-					}
-				}
-			}
-		}
 	}
 
 	/* Playback */

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -630,6 +630,7 @@ uint8_t FACT_INTERNAL_CreateSound(FACTCue *cue, uint16_t fadeInMS)
 
 				newSound->tracks[i].events[j].timestamp =
 					newSound->sound->tracks[i].events[j].timestamp;
+				newSound->tracks[i].events[j].loopCount = 0;
 				newSound->tracks[i].events[j].finished = 0;
 				newSound->tracks[i].events[j].value = 0.0f;
 

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -822,12 +822,12 @@ void FACT_INTERNAL_UpdateRPCs(
 	uint32_t *codes,
 	FACTInstanceRPCData *data,
 	uint32_t timestamp,
-	uint32_t elapsedCue,
 	uint32_t elapsedTrack
 ) {
 	uint8_t i;
 	FACTRPC *rpc;
 	float rpcResult;
+	float variableValue;
 	FACTAudioEngine *engine = cue->parentBank->parentEngine;
 
 	if (codeCount > 0)
@@ -845,7 +845,6 @@ void FACT_INTERNAL_UpdateRPCs(
 			);
 			if (engine->variables[rpc->variable].accessibility & 0x04)
 			{
-				float variableValue;
 				if (FAudio_strcmp(
 					engine->variableNames[rpc->variable],
 					"AttackTime"
@@ -1259,7 +1258,6 @@ uint8_t FACT_INTERNAL_UpdateSound(FACTSoundInstance *sound, uint32_t timestamp)
 		sound->sound->rpcCodes,
 		&sound->rpcData,
 		timestamp,
-		elapsedCue,
 		elapsedCue - sound->tracks[0].events[0].timestamp
 	);
 	for (i = 0; i < sound->sound->trackCount; i += 1)
@@ -1271,7 +1269,6 @@ uint8_t FACT_INTERNAL_UpdateSound(FACTSoundInstance *sound, uint32_t timestamp)
 			sound->sound->tracks[i].rpcCodes,
 			&sound->tracks[i].rpcData,
 			timestamp,
-			elapsedCue,
 			elapsedCue - sound->sound->tracks[i].events[0].timestamp
 		);
 	}

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -1335,7 +1335,7 @@ uint8_t FACT_INTERNAL_UpdateSound(FACTSoundInstance *sound, uint32_t timestamp)
 				finished = 0;
 
 				/* Trigger events at the right time */
-				if (elapsedCue > evtInst->timestamp)
+				if (elapsedCue >= evtInst->timestamp)
 				{
 					FACT_INTERNAL_ActivateEvent(
 						sound,

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -698,10 +698,11 @@ uint8_t FACT_INTERNAL_CreateSound(FACTCue *cue, uint16_t fadeInMS)
 				);
 				if (cue->parentBank->parentEngine->variables[rpc->variable].accessibility & 0x04)
 				{
-					if (FAudio_strcmp(
-						newSound->parentCue->parentBank->parentEngine->variableNames[rpc->variable],
-						"ReleaseTime"
-					) == 0 && rpc->parameter == RPC_PARAMETER_VOLUME)
+					if (	rpc->parameter == RPC_PARAMETER_VOLUME &&
+							FAudio_strcmp(
+								newSound->parentCue->parentBank->parentEngine->variableNames[rpc->variable],
+								"ReleaseTime"
+							) == 0	)
 					{
 						lastX = rpc->points[rpc->pointCount - 1].x;
 						if (lastX > cue->maxRpcReleaseTime)
@@ -1082,12 +1083,12 @@ void FACT_INTERNAL_ActivateEvent(
 				}
 			}
 			else
-			{
-				FACT_INTERNAL_BeginFadeOut(
-					sound,
-					sound->parentCue->parentBank->cues[sound->parentCue->index].fadeOutMS
-				);
-			}
+				{
+					FACT_INTERNAL_BeginFadeOut(
+						sound,
+						sound->parentCue->parentBank->cues[sound->parentCue->index].fadeOutMS
+					);
+				}
 		}
 
 		/* Stop track */

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -630,8 +630,6 @@ uint8_t FACT_INTERNAL_CreateSound(FACTCue *cue, uint16_t fadeInMS)
 
 				newSound->tracks[i].events[j].timestamp =
 					newSound->sound->tracks[i].events[j].timestamp;
-				newSound->tracks[i].events[j].loopCount =
-					newSound->sound->tracks[i].events[j].wave.loopCount;
 				newSound->tracks[i].events[j].finished = 0;
 				newSound->tracks[i].events[j].value = 0.0f;
 
@@ -640,6 +638,9 @@ uint8_t FACT_INTERNAL_CreateSound(FACTCue *cue, uint16_t fadeInMS)
 					evt->type == FACTEVENT_PLAYWAVEEFFECTVARIATION ||
 					evt->type == FACTEVENT_PLAYWAVETRACKEFFECTVARIATION	)
 				{
+					newSound->tracks[i].events[j].loopCount =
+						newSound->sound->tracks[i].events[j].wave.loopCount;
+
 					evtInst = &newSound->tracks[i].events[j];
 					if (	!evt->wave.isComplex ||
 						(evt->wave.complex.variation & 0xF) == 0	)
@@ -674,6 +675,12 @@ uint8_t FACT_INTERNAL_CreateSound(FACTCue *cue, uint16_t fadeInMS)
 					);
 					newSound->tracks[i].waveEvt = evt;
 					newSound->tracks[i].waveEvtInst = evtInst;
+				}
+				else if (	evt->type == FACTEVENT_PITCHREPEATING ||
+					evt->type == FACTEVENT_VOLUMEREPEATING	)
+				{
+					newSound->tracks[i].events[j].loopCount =
+						newSound->sound->tracks[i].events[j].value.repeats;
 				}
 			}
 		}
@@ -1183,7 +1190,7 @@ void FACT_INTERNAL_ActivateEvent(
 		}
 		if (evtInst->loopCount > 0)
 		{
-			if (evtInst->loopCount != 0xFF)
+			if (evtInst->loopCount != 0xFF && evtInst->loopCount != 0xFFFF)
 			{
 				evtInst->loopCount -= 1;
 			}

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -1071,7 +1071,8 @@ void FACT_INTERNAL_ActivateEvent(
 		if (evt->stop.flags & 0x02)
 		{
 			if (	evt->stop.flags & 0x01 ||
-				sound->parentCue->parentBank->cues[sound->parentCue->index].fadeOutMS == 0	)
+				(sound->parentCue->parentBank->cues[sound->parentCue->index].fadeOutMS == 0 &&
+				sound->parentCue->maxRpcReleaseTime == 0)	)
 			{
 				for (i = 0; i < sound->sound->trackCount; i += 1)
 				{
@@ -1083,12 +1084,22 @@ void FACT_INTERNAL_ActivateEvent(
 				}
 			}
 			else
+			{
+				if (sound->parentCue->parentBank->cues[sound->parentCue->index].fadeOutMS > 0)
 				{
 					FACT_INTERNAL_BeginFadeOut(
 						sound,
 						sound->parentCue->parentBank->cues[sound->parentCue->index].fadeOutMS
 					);
 				}
+				else if (sound->parentCue->maxRpcReleaseTime > 0)
+				{
+					FACT_INTERNAL_BeginReleaseRPC(
+						sound,
+						sound->parentCue->maxRpcReleaseTime
+					);
+				}
+			}
 		}
 
 		/* Stop track */

--- a/src/FACT_internal.h
+++ b/src/FACT_internal.h
@@ -344,7 +344,7 @@ typedef struct FACTSoundInstance
 	/* Fade data */
 	uint16_t fadeStart;
 	uint16_t fadeTarget;
-	uint8_t fadeType; /* 1 for in, 2 for out */
+	uint8_t fadeType; /* In (1), Out (2), Release RPC (3) */
 
 	/* Engine references */
 	FACTCue *parentCue;
@@ -485,6 +485,7 @@ struct FACTCue
 
 	/* Sound data */
 	FACTCueData *data;
+
 	union
 	{
 		FACTVariationTable *variation;
@@ -505,6 +506,7 @@ struct FACTCue
 	FACTWave *simpleWave;
 	FACTSoundInstance *playingSound;
 	FACTVariation *playingVariation;
+	uint32_t maxRpcReleaseTime;
 
 	/* 3D Data */
 	uint8_t active3D;
@@ -531,6 +533,11 @@ void FACT_INTERNAL_GetNextWave(
 uint8_t FACT_INTERNAL_CreateSound(FACTCue *cue, uint16_t fadeInMS);
 void FACT_INTERNAL_DestroySound(FACTSoundInstance *sound);
 void FACT_INTERNAL_BeginFadeOut(FACTSoundInstance *sound, uint16_t fadeOutMS);
+void FACT_INTERNAL_BeginReleaseRPC(FACTSoundInstance *sound, uint16_t releaseMS);
+
+/* RPC Helper Functions */
+
+FACTRPC* FACT_INTERNAL_GetRPC(FACTAudioEngine *engine, uint32_t code);
 
 /* FACT Thread */
 

--- a/src/FACT_internal.h
+++ b/src/FACT_internal.h
@@ -342,7 +342,7 @@ typedef struct FACTSoundInstance
 	FACTInstanceRPCData rpcData;
 
 	/* Fade data */
-	uint16_t fadeStart;
+	uint32_t fadeStart;
 	uint16_t fadeTarget;
 	uint8_t fadeType; /* In (1), Out (2), Release RPC (3) */
 

--- a/src/FACT_internal.h
+++ b/src/FACT_internal.h
@@ -485,7 +485,6 @@ struct FACTCue
 
 	/* Sound data */
 	FACTCueData *data;
-
 	union
 	{
 		FACTVariationTable *variation;


### PR DESCRIPTION
Implement attack/release RPC similar to C# FNA XACT implementation.

For attack envelopes:
- Simply compute the time into the attack envelope.

For release envelopes:
- When creating a cue instance scan each tracks Release RPC channels to compute an upper bound on how long the sounds release can be. This is an over simplification as it doesn't take into account which tracks were playing at the time of a stop as authored state change. In the worst case it just means that the cue becomes fully silent and stays in the Stopping state longer than it needs to.
- When the sound is stopped as authored, put the sound into a special release state using the computed maximum release time.
- When in the release state, compute the time into the release envelope and keep playing and processing the RPC curves until the release state is complete.