### PR TITLE
Minor tweaks

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -26,7 +26,7 @@ Because cross-compiling is fun.
 #### Building
 The project includes two shell scripts to set up your environment for cross-compilation: either for 32-bit or 64-bit Windows DLLs.
 
-- ```source``` either ```scrips/cross_compile_32``` or ```scripts/cross_compile_64```
+- ```source``` either ```scripts/cross_compile_32``` or ```scripts/cross_compile_64```
 - (optional) check if ```sdl-config --libs``` prints the correct directory 
     - if not: update the cross-compilation scripts
 - cross-compile FACT: ```make clean all``` in the root directory of FACT

--- a/cpp/scripts/cross_compile_32
+++ b/cpp/scripts/cross_compile_32
@@ -7,7 +7,7 @@ MINGW=i686-w64-mingw32
 
 if [ ! -f $SDL_CROSS_PATH/$MINGW/bin/sdl2-config ]; then
 	echo "Please check your mingw32 SDL installation"
-	exit -1
+	return -1
 fi
 
 export PATH=$SDL_CROSS_PATH/$MINGW/bin:$PATH

--- a/cpp/scripts/cross_compile_64
+++ b/cpp/scripts/cross_compile_64
@@ -7,7 +7,7 @@ MINGW=x86_64-w64-mingw32
 
 if [ ! -f $SDL_CROSS_PATH/$MINGW/bin/sdl2-config ]; then
 	echo "Please check your mingw32 SDL installation"
-	exit -1
+	return -1
 fi
 
 export PATH=$SDL_CROSS_PATH/$MINGW/bin:$PATH


### PR DESCRIPTION
* fix typo in the documentation 
* tweak wrapper cross-compilation scripts: use `return` instead of `exit` to avoid killing the shell on error handling when sourced.