### PR TITLE
GCC utils fix

### DIFF
--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -156,6 +156,11 @@ __declspec(dllimport) void __stdcall CoTaskMemFree(void* pv);
 	#endif
 #endif
 
+/* C++ does not have restrict (though VS2012+ does have __restrict) */
+#if defined(__cplusplus) && !defined(restrict)
+#define restrict
+#endif
+
 /* Threading Types */
 
 typedef void* FAudioThread;


### PR DESCRIPTION
ecadcb7c652b3a90bd78cb1e3091b33a83a198ff broke compilation of utils on Linux. At least it did for me with GCC 7.3.