### PR TITLE
Use libsamplerate for sample ratio conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,16 @@ ifeq ($(FAUDIO_FFMPEG), 1)
 	LDFLAGS += $(FFMPEG_LDFLAGS)
 endif
 
+# libsamplerate for high quality samplerate conversion
+ifeq ($(FAUDIO_LIBSAMPLERATE), 1)
+	LIBSAMPLERATE_CFLAGS = `pkg-config samplerate --cflags`
+	LIBSAMPLERATE_LDFLAGS = `pkg-config samplerate --libs`
+
+	LIBSAMPLERATE_CFLAGS += -DHAVE_LIBSAMPLERATE=1
+
+	CFLAGS += $(LIBSAMPLERATE_CFLAGS)
+	LDFLAGS += $(LIBSAMPLERATE_LDFLAGS)
+endif
 
 # Object code lists
 ifneq ($(FAUDIO_OUT),)

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -27,6 +27,10 @@
 #include "FAudio.h"
 #include "FAPOBase.h"
 
+#if HAVE_LIBSAMPLERATE
+#include <samplerate.h>
+#endif
+
 #ifdef FAUDIO_UNKNOWN_PLATFORM
 #include <stdlib.h>
 #include <string.h>
@@ -316,6 +320,12 @@ struct FAudioVoice
 #ifdef HAVE_FFMPEG
 			struct FAudioFFmpeg *ffmpeg;
 #endif /* HAVE_FFMPEG*/
+
+			/* libsamplerate */
+#if HAVE_LIBSAMPLERATE
+			SRC_STATE *libsrc;
+			double libsrc_ratio;
+#endif
 
 			/* Read-only */
 			float maxFreqRatio;


### PR DESCRIPTION
This adds an optional dependency on [libsamplerate](http://www.mega-nerd.com/SRC/). This is a small, stable, high quality samplerate conversion library which is BSD licensed since 2016.

I'd highly recommend making this a non-optional dependency, so we can remove the linear resamplers and simplify the decoding/resampling code. I think it should be easy to port to your various platforms. If you're OK with that, I can begin that work (or you can do it).