### PR TITLE
check for iconv before copying or linking, fix bracket issue in wine_…

### DIFF
--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -11,6 +11,9 @@ else
 	BUILD_DIR = build_win32
 endif
 
+#Mingw dir
+MINGW_DIR = $(shell sdl2-config --prefix)
+
 # Source lists
 XAPO_SRC = XAPOBase.cpp
 
@@ -290,11 +293,16 @@ $(BUILD_DIR)/xactdll_x30.o: xact3_7.def
 
 directories:
 	mkdir -p $(BUILD_DIR)
+
 	cp ../FAudio.dll $(BUILD_DIR)
-	cp `sdl2-config --prefix`/bin/SDL2.dll $(BUILD_DIR)
-	cp `sdl2-config --prefix`/bin/libwinpthread*.dll $(BUILD_DIR)
-	cp `sdl2-config --prefix`/bin/libiconv*.dll $(BUILD_DIR)
-	if [ -n "${FAUDIO_FFMPEG}" ] && [ -n "${FAUDIO_FFMPEG_PREFIX}" ]; then	\
+	cp $(MINGW_DIR)/bin/SDL2.dll $(BUILD_DIR)
+	cp $(MINGW_DIR)/bin/libwinpthread*.dll $(BUILD_DIR)
+
+	if [ -f $(MINGW_DIR)/bin/libiconv*.dll ]; then \
+		cp $(MINGW_DIR)/bin/libiconv*.dll $(BUILD_DIR); \
+	fi
+
+	if [ -n $(FAUDIO_FFMPEG) ] && [ -n $(FAUDIO_FFMPEG_PREFIX) ]; then	\
 		cp $(FAUDIO_FFMPEG_PREFIX)/bin/avcodec*.dll $(BUILD_DIR);	\
 		cp $(FAUDIO_FFMPEG_PREFIX)/bin/avutil*.dll $(BUILD_DIR);	\
 		cp $(FAUDIO_FFMPEG_PREFIX)/bin/swresample*.dll $(BUILD_DIR);	\

--- a/cpp/Makefile
+++ b/cpp/Makefile
@@ -11,7 +11,7 @@ else
 	BUILD_DIR = build_win32
 endif
 
-#Mingw dir
+# Mingw dir
 MINGW_DIR = $(shell sdl2-config --prefix)
 
 # Source lists

--- a/cpp/scripts/wine_setup_native
+++ b/cpp/scripts/wine_setup_native
@@ -83,17 +83,20 @@ install_dll xapofx1_5
 ln -sf "$dll_path/FAudio.dll" "$wine_path/FAudio.dll"
 ln -sf "$dll_path/SDL2.dll" "$wine_path/SDL2.dll"
 ln -sf "$dll_path/libwinpthread-1.dll" "$wine_path/libwinpthread-1.dll"
-ln -sf "$dll_path/libiconv-2.dll" "$wine_path/libiconv-2.dll"
 
-if [ -f "$dll_path/avcodec-58.dll"];then 
+if [ -f "$dll_path/libiconv-2.dll" ];then 
+	ln -sf "$dll_path/libiconv-2.dll" "$wine_path/libiconv-2.dll"
+fi
+
+if [ -f "$dll_path/avcodec-58.dll" ];then 
 	ln -sf "$dll_path/avcodec-58.dll" "$wine_path/avcodec-58.dll"
 fi
 
-if [ -f "$dll_path/avutil-56.dll"];then 
+if [ -f "$dll_path/avutil-56.dll" ];then 
 	ln -sf "$dll_path/avutil-56.dll" "$wine_path/avutil-56.dll"
 fi
 
-if [ -f "$dll_path/swresample-3.dll"];then 
+if [ -f "$dll_path/swresample-3.dll" ];then 
 	ln -sf "$dll_path/swresample-3.dll" "$wine_path/swresample-3.dll"
 fi
 


### PR DESCRIPTION
…setup_native

turns out iconv only gets used when compiling ffmpeg's avcodec if it's present, so we need to conditionally check if it exists before copying it over.