### PR TITLE
RFC: Add new entry point for clients to wrap the engine procedure

### DIFF
--- a/extensions/EngineProcedureEXT.txt
+++ b/extensions/EngineProcedureEXT.txt
@@ -1,0 +1,35 @@
+EngineProcedureEXT - Allow clients to wrap engine procedure
+
+About
+-----
+Clients may be interested in having more control over the engine procedure. In
+particular, they may want to modify or access the generated output before
+passing it to the underlying platform. In other cases, clients like Wine may
+have specific thread requirements that the platform's audio library cannot
+satisfy. This extension allows clients to "wrap" the engine procedure with
+arbitrary code.
+
+New Types
+---------
+typedef void (FAUDIOCALL *FAudioEngineCallEXT)(FAudio *audio, float *output);
+
+typedef void (FAUDIOCALL *FAudioEngineProcedureEXT)(FAudioEngineCall defaultEngineProc, FAudio *audio, float *output, void *user);
+
+New Procedures and Functions
+----------------------------
+FAUDIOAPI void FAudio_SetEngineProcedureEXT(
+	FAudio *audio,
+	FAudioEngineProcedure clientEngineProc,
+	void *user
+);
+
+How to Use
+----------
+At any time, the client may request that FAudio call the given
+clientEngineProc function instead of FAudio's default engine procedure
+beginning with the next engine tick. It is valid to call
+FAudio_SetEngineProcedureEXT before creating the mastering voice.
+
+clientEngineProc will be invoked with a pointer to FAudio's default engine
+procedure, allowing the client to execute the procedure on a specific thread,
+or operate on the retrieved audio before returning control back to FAudio.

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -556,6 +556,15 @@ uint32_t FAudio_CreateMasteringVoice8(
 	);
 }
 
+void FAudio_SetEngineProcedureEXT(
+	FAudio *audio,
+	FAudioEngineProcedureEXT clientEngineProc,
+	void *user
+) {
+	audio->pClientEngineProc = clientEngineProc;
+	audio->clientEngineUser = user;
+}
+
 uint32_t FAudio_StartEngine(FAudio *audio)
 {
 	audio->active = 1;

--- a/src/FAudio.h
+++ b/src/FAudio.h
@@ -774,6 +774,19 @@ FAUDIOAPI uint32_t FAudioCOMConstructWithCustomAllocatorEXT(
 	FAudioReallocFunc customRealloc
 );
 
+/* FAudio Engine Procedure API
+ * See "extensions/EngineProcedureEXT.txt" for more information.
+ */
+typedef void (FAUDIOCALL *FAudioEngineCallEXT)(FAudio *audio, float *output);
+typedef void (FAUDIOCALL *FAudioEngineProcedureEXT)(FAudioEngineCallEXT defaultEngineProc, FAudio *audio, float *output, void *user);
+
+FAUDIOAPI void FAudio_SetEngineProcedureEXT(
+	FAudio *audio,
+	FAudioEngineProcedureEXT clientEngineProc,
+	void *user
+);
+
+
 /* FAudio I/O API */
 
 #define FAUDIO_SEEK_SET 0

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -905,7 +905,7 @@ end:
 	);
 }
 
-void FAudio_INTERNAL_UpdateEngine(FAudio *audio, float *output)
+static void FAUDIOCALL FAudio_INTERNAL_GenerateOutput(FAudio *audio, float *output)
 {
 	uint32_t totalSamples;
 	LinkedList *list;
@@ -1009,6 +1009,23 @@ void FAudio_INTERNAL_UpdateEngine(FAudio *audio, float *output)
 		list = list->next;
 	}
 	FAudio_PlatformUnlockMutex(audio->callbackLock);
+}
+
+void FAudio_INTERNAL_UpdateEngine(FAudio *audio, float *output)
+{
+	if (audio->pClientEngineProc)
+	{
+		audio->pClientEngineProc(
+			&FAudio_INTERNAL_GenerateOutput,
+			audio,
+			output,
+			audio->clientEngineUser
+		);
+	}
+	else
+	{
+		FAudio_INTERNAL_GenerateOutput(audio, output);
+	}
 }
 
 void FAudio_INTERNAL_ResizeDecodeCache(FAudio *audio, uint32_t samples)

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -273,6 +273,9 @@ struct FAudio
 	FAudioMallocFunc pMalloc;
 	FAudioFreeFunc pFree;
 	FAudioReallocFunc pRealloc;
+
+	void *clientEngineUser;
+	FAudioEngineProcedureEXT pClientEngineProc;
 };
 
 struct FAudioVoice


### PR DESCRIPTION
You can view the accompanying Wine changes at https://github.com/aeikum/wine/commits/engineproc