### PR TITLE
[On Hold] Allow multiple SDL handles per device

### DIFF
--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -289,6 +289,9 @@ struct FAudio
 	/* Debug Information */
 	FAudioDebugConfiguration debug;
 #endif
+
+	/* Platform opaque pointer */
+	void *platform;
 };
 
 struct FAudioVoice


### PR DESCRIPTION
This fixes audio in WWE2k19, which first opens an 11kHz xaudio device, and then a separate 48kHz device and expects low latency on the latter.

This removes the global tracking of platform devices and instead tracks them in the FAudio object. This shouldn't break any external platform backends(?), but they might want to change to use the new platform pointer instead of a global list, for consistency.

The game uses GetState to maintain 4 buffers in the queue, so this debugging was useful there.