### PR TITLE
Always take into consideration PKG_CONFIG_FILE and use only pkg-confi…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,12 @@ ifeq ($(FAUDIO_RELEASE),1)
 else
 	CFLAGS += -g -Wall
 endif
-LDFLAGS += `sdl2-config --libs`
+
+ifdef PKG_CONFIG_PATH
+	PKG_CONFIG_PATH ?= 
+endif
+
+LDFLAGS += `pkg-config sdl2 --libs`
 
 # Source lists
 FAUDIOSRC = \
@@ -102,7 +107,7 @@ all: $(FAUDIOOBJ)
 	$(CC) $(CFLAGS) -shared -o $(FAUDIOLIB) $(FAUDIOOBJ) $(LDFLAGS)
 
 $(FAUDIO_OUT)/%.o: src/%.c
-	$(CC) $(CFLAGS) -c -o $@ $< `sdl2-config --cflags`
+	$(CC) $(CFLAGS) -c -o $@ $< `pkg-config sdl2 --cflags`
 
 clean:
 	rm -f $(FAUDIOOBJ) $(FAUDIOLIB) testparse$(UTIL_SUFFIX) facttool$(UTIL_SUFFIX) testreverb$(UTIL_SUFFIX) testvolumemeter$(UTIL_SUFFIX) testfilter$(UTIL_SUFFIX) testxwma$(UTIL_SUFFIX)
@@ -135,36 +140,36 @@ testparse:
 	$(CC) -g -Wall -pedantic -o testparse$(UTIL_SUFFIX) \
 		utils/testparse/testparse.c \
 		src/F*.c \
-		-Isrc `sdl2-config --cflags --libs`
+		-Isrc `pkg-config sdl2 --cflags --libs`
 
 facttool:
 	$(CXX) -g -Wall $(FFMPEG_CFLAGS) -o facttool$(UTIL_SUFFIX) \
 		utils/facttool/facttool.cpp \
 		utils/uicommon/*.cpp src/F*.c \
-		-Isrc `sdl2-config --cflags --libs` $(FFMPEG_LDFLAGS)
+		-Isrc `pkg-config sdl2 --cflags --libs` $(FFMPEG_LDFLAGS)
 
 testreverb:
 	$(CXX) -g -Wall -o testreverb$(UTIL_SUFFIX) \
 		utils/testreverb/*.cpp \
 		utils/wavcommon/wavs.cpp \
 		utils/uicommon/*.cpp src/F*.c \
-		-Isrc `sdl2-config --cflags --libs`
+		-Isrc `pkg-config sdl2 --cflags --libs`
 
 testvolumemeter:
 	$(CXX) -g -Wall -o testvolumemeter$(UTIL_SUFFIX) \
 		utils/testvolumemeter/*.cpp \
 		utils/wavcommon/wavs.cpp \
 		utils/uicommon/*.cpp src/F*.c \
-		-Isrc `sdl2-config --cflags --libs`
+		-Isrc `pkg-config sdl2 --cflags --libs`
 
 testxwma:
 	$(CXX) -g -Wall $(FFMPEG_CFLAGS) -o testxwma$(UTIL_SUFFIX) \
 		utils/testxwma/*.cpp \
 		src/F*.c \
-		-Isrc `sdl2-config --cflags --libs` $(FFMPEG_LDFLAGS)
+		-Isrc `pkg-config sdl2 --cflags --libs` $(FFMPEG_LDFLAGS)
 
 testfilter:
 	$(CXX) -g -Wall -o testfilter$(UTIL_SUFFIX) \
 		utils/testfilter/*.cpp \
 		utils/uicommon/*.cpp src/F*.c \
-		-Isrc `sdl2-config --cflags --libs`
+		-Isrc `pkg-config sdl2 --cflags --libs`


### PR DESCRIPTION
…g to avoid unnecessary extra binary usage

In some cases I found PKG_CONFIG_FILE was not being taken into consideration (such as Arch's PKGBUILD system). This would cause pkg-config lines to detect incorrect libraries, even if PKG_CONFIG_PATH was specified. Example:

```
/usr/bin/ld: skipping incompatible /usr/lib/libSDL2.so when searching for -lSDL2
/usr/bin/ld: skipping incompatible /usr/lib/libavcodec.so when searching for -lavcodec
/usr/bin/ld: skipping incompatible /usr/lib/libavutil.so when searching for -lavutil
/usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
/usr/bin/ld: skipping incompatible /usr/lib/libpthread.so when searching for -lpthread
/usr/bin/ld: skipping incompatible /usr/lib/libpthread.a when searching for -lpthread
/usr/bin/ld: skipping incompatible /usr/lib/libc.so when searching for -lc
/usr/bin/ld: skipping incompatible /usr/lib/libc.a when searching for -lc
/usr/bin/ld: skipping incompatible /usr/lib/libgcc_s.so.1 when searching for libgcc_s.so.1
```
Further, if compiling with proton, using sdl2-config requires setting an extra environment bin path in addition to the extra lib path. We can avoid this by using `pkg-config sdl2` for our --libs and --cflags instead, just as other packages.

This should help various distro build systems by allowing them to specify PKG_CONFIG_PATH for 32 bit should the above error occur when compiling 32 bit.