### PR TITLE
Zero output buffer before calling FAPO::Process

### DIFF
--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -613,6 +613,8 @@ static inline float *FAudio_INTERNAL_ProcessEffectChain(
 			{
 				dstParams.pBuffer = buffer;
 			}
+
+			memset(dstParams.pBuffer, 0, voice->effects.desc[i].OutputChannels * samples * sizeof(float));
 		}
 
 		if (voice->effects.parameterUpdates[i])


### PR DESCRIPTION
Hellblade: Senua's Sacrifice mixes into the output buffer instead of
ovewriting it.