### PR TITLE
convert README to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,55 @@
+# FAudio
 This is FAudio, an XAudio reimplementation that focuses solely on developing
 fully accurate DirectX Audio runtime libraries for the FNA project, including
 XAudio2, X3DAudio, XAPO, and XACT3.
 
 Project Website: http://fna-xna.github.io/
 
-License
--------
+## License
 FAudio is released under the zlib license. See LICENSE for details.
 
-About FAudio
-------------
+## About FAudio
 FAudio was written to be used for FNA's Audio/Media namespaces. We access this
 library via FAudio#, which you can find in the 'csharp/' directory.
 
-Dependencies
-------------
+## Dependencies
 FAudio depends solely on SDL2. FAudio never explicitly uses the C runtime.
 
-Building FAudio
----------------
+## Building FAudio
 For *nix platforms, use cmake.
 
-    $ mkdir build/
-    $ cd build/
-    $ cmake ../
-    $ make
+```sh
+$ mkdir build/
+$ cd build/
+$ cmake ../
+$ make
+```
 
-For Windows, see the 'visualc/' directory.
+For Windows, see the [visualc/](visualc) directory.
 
-For Xbox One, see the 'visualc-winrt/' directory.
+For Xbox One, see the [visualc-winrt/](visualc-winrt) directory.
 
-For iOS/tvOS, see the 'Xcode-iOS/' directory.
+For iOS/tvOS, see the [Xcode-iOS](Xcode-iOS) directory.
 
-Unit tests
-----------
+## Unit tests
 FAudio includes a set of unit tests which document the behavior of XAudio2 and
 are to be run against FAudio to verify it has the same behavior. The tests are
-NOT built by default; set BUILD_TESTS=1 to build and then run the output with:
+NOT built by default; set `BUILD_TESTS=1` to build and then run the output with:
 
+```sh
     $ ./faudio_tests
+```
 
 To build a Windows executable to run the tests against XAudio2, use the
 provided Makefile. This requires mingw-w64 to build.
 
+```sh
     $ cd tests/
     $ make faudio_tests.exe
     # run faudio_texts.exe on a Windows box
+```
 
-Found an issue?
----------------
+## Found an issue?
 Issues and patches can be reported via GitHub:
 
 https://github.com/FNA-XNA/FAudio/issues


### PR DESCRIPTION
use markdown for main readme file. Later the build status tag can be easily integrated