### PR TITLE
Fix PlayWave variations

### DIFF
--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -1658,17 +1658,6 @@ void FACT_INTERNAL_OnBufferEnd(FAudioVoiceCallback *callback, void* pContext)
 		left
 	);
 
-	/* Last buffer in the stream? */
-	if (	buffer.AudioBytes < c->wave->streamSize &&
-		c->wave->loopCount == 0	)
-	{
-		buffer.Flags = FAUDIO_END_OF_STREAM;
-	}
-	else
-	{
-		buffer.Flags = 0;
-	}
-
 	/* Read! */
 	ovlp.Internal = NULL;
 	ovlp.InternalHigh = NULL;
@@ -1688,18 +1677,26 @@ void FACT_INTERNAL_OnBufferEnd(FAudioVoiceCallback *callback, void* pContext)
 		&read,
 		1
 	);
-
-	/* Loop if applicable */
 	c->wave->streamOffset += buffer.AudioBytes;
-	if (	c->wave->streamOffset >= end &&
-		c->wave->loopCount > 0	)
+
+	/* Last buffer in the stream? */
+	buffer.Flags = 0;
+	if (c->wave->streamOffset >= end)
 	{
-		if (c->wave->loopCount != 255)
+		/* Loop if applicable */
+		if (c->wave->loopCount > 0)
 		{
-			c->wave->loopCount -= 1;
+			if (c->wave->loopCount != 255)
+			{
+				c->wave->loopCount -= 1;
+			}
+			/* TODO: Loop start */
+			c->wave->streamOffset = entry->PlayRegion.dwOffset;
 		}
-		/* TODO: Loop start */
-		c->wave->streamOffset = entry->PlayRegion.dwOffset;
+		else
+		{
+			buffer.Flags = FAUDIO_END_OF_STREAM;
+		}
 	}
 
 	/* Unused properties */


### PR DESCRIPTION
The root of this issue was that FAUDIO_END_OF_STREAM wasn't reliable getting set and used to guard which callback should be called (EndOfBuffer or EndOfStream).  This resulted in cases where FACT_STATE_STOPPED wasn't being transitioned to, leading to pre-loading the next wave not happening.

The symptom is that the first track in the PlayWave event would play, but then would remain silent afterward never ending.

Non-streaming sounds do not encounter this issue since they always process and a single big enough buffer at once.

I put an assert in an old code path that I don't think is necessary anymore since the callback will only be called when there is work to do.