### PR TITLE
Fix cmake REGEX escaped character; add second backslash

### DIFF
--- a/cmake/install_shared_libs.cmake
+++ b/cmake/install_shared_libs.cmake
@@ -42,7 +42,7 @@ function(install_shared_libs)
 		endif()
 
 		# got an absolute path for a library
-		string(REGEX MATCH "\.(dll.a$|lib$)" is_static "${lib}")
+		string(REGEX MATCH "\\.(dll.a$|lib$)" is_static "${lib}")
 		if(is_static)
 			# lib is a dynamic wrapper ending in .dll.a, search for the linked
 			# dll in the ../bin directory
@@ -59,7 +59,7 @@ function(install_shared_libs)
 				set(lib "${dyn_lib}")
 			endif()
 		endif()
-		string(REGEX MATCH "\.(so|dll$)" is_shared_lib "${lib}")
+		string(REGEX MATCH "\\.(so|dll$)" is_shared_lib "${lib}")
 		if(NOT is_shared_lib)
 			# don't install static libraries
 			message(STATUS "ignore static lib: ${lib}")


### PR DESCRIPTION
Hit a CMake error building the native dlls following the CMake requirement downgrade aecb21034718abcea6115bd2e4853de6913b6643

https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/VariablesListsStrings#using-cmake-regexps

```
CMake Error at cmake/install_shared_libs.cmake:45 (string):
  Syntax error in cmake code at

    FAudio/cmake/install_shared_libs.cmake:45

  when parsing string

    \.(dll.a$|lib$)

  Invalid escape sequence \.
Call Stack (most recent call first):
  CMakeLists.txt:140 (install_shared_libs)
```

Build logs: git version is shown under 
```
==> Starting pkgver()...
==> Updated version: faudio-wrappers-git r${commitnumber}.${commitref}-1
```
5056ea9 build https://gitlab.com/archlinux-packages-johnth/mingw-w64-faudio-git/-/jobs/162963157
aecb210^ (5736333) build https://gitlab.com/archlinux-packages-johnth/mingw-w64-faudio-git/-/jobs/162965865
f7390c5 cmake regex fix build https://gitlab.com/archlinux-packages-johnth/mingw-w64-faudio-git/-/jobs/162960726

Cheers