### PR TITLE
dump audio buffer to wav files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 option(XNASONG "Build with XNA_Song.c" ON)
 option(LOG_ASSERTIONS "Bind FAudio_assert to log, instead of platform's assert" OFF)
 option(FORCE_ENABLE_DEBUGCONFIGURATION "Enable DebugConfiguration in all build types" OFF)
+option(DUMP_VOICES "Dump voices to RIFF WAVE files" OFF)
 if(WIN32)
 option(INSTALL_MINGW_DEPENDENCIES "Add dependent libraries to MinGW install target" OFF)
 endif()
@@ -154,6 +155,11 @@ if(FFMPEG)
 		install_shared_libs(FILES ${FFmpeg_LIBRARIES} DESTINATION bin NO_INSTALL_SYMLINKS REQUIRED)
 	endif()
 endif(FFMPEG)
+
+# Dump source voices to RIFF WAVE files
+if(DUMP_VOICES)
+	target_compile_definitions(FAudio PRIVATE FAUDIO_DUMP_VOICES)
+endif()
 
 # SDL2 Dependency
 if (DEFINED SDL2_INCLUDE_DIRS AND DEFINED SDL2_LIBRARIES)

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -844,4 +844,30 @@ static inline void WriteWaveFormatExtensible(
 	((fxd & FIXED_FRACTION_MASK) * (1.0f / FIXED_ONE)) /* Fraction part */ \
 )
 
+#ifdef FAUDIO_DUMP_VOICES
+/* File writing structure */
+typedef size_t (FAUDIOCALL * FAudio_writefunc)(
+	void *data,
+	const void *src,
+	size_t size,
+	size_t count
+);
+typedef size_t (FAUDIOCALL * FAudio_sizefunc)(
+	void *data
+);
+typedef struct FAudioIOStreamOut
+{
+	void *data;
+	FAudio_readfunc read;
+	FAudio_writefunc write;
+	FAudio_seekfunc seek;
+	FAudio_sizefunc size;
+	FAudio_closefunc close;
+	void *lock;
+} FAudioIOStreamOut;
+
+FAudioIOStreamOut* FAudio_fopen_out(const char *path, const char *mode);
+void FAudio_close_out(FAudioIOStreamOut *io);
+#endif /* FAUDIO_DUMP_VOICES */
+
 /* vim: set noexpandtab shiftwidth=8 tabstop=8: */

--- a/src/FAudio_platform_sdl2.c
+++ b/src/FAudio_platform_sdl2.c
@@ -322,6 +322,31 @@ void FAudio_close(FAudioIOStream *io)
 	FAudio_free(io);
 }
 
+#ifdef FAUDIO_DUMP_VOICES
+FAudioIOStreamOut* FAudio_fopen_out(const char *path, const char *mode)
+{
+	FAudioIOStreamOut *io = (FAudioIOStreamOut*) SDL_malloc(
+		sizeof(FAudioIOStreamOut)
+	);
+	SDL_RWops *rwops = SDL_RWFromFile(path, mode);
+	io->data = rwops;
+	io->read = (FAudio_readfunc) rwops->read;
+	io->write = (FAudio_writefunc) rwops->write;
+	io->seek = (FAudio_seekfunc) rwops->seek;
+	io->size = (FAudio_sizefunc) rwops->size;
+	io->close = (FAudio_closefunc) rwops->close;
+	io->lock = FAudio_PlatformCreateMutex();
+	return io;
+}
+
+void FAudio_close_out(FAudioIOStreamOut *io)
+{
+	io->close(io->data);
+	FAudio_PlatformDestroyMutex((FAudioMutex) io->lock);
+	FAudio_free(io);
+}
+#endif /* FAUDIO_DUMP_VOICES */
+
 /* UTF8->UTF16 Conversion, taken from PhysicsFS */
 
 #define UNICODE_BOGUS_CHAR_VALUE 0xFFFFFFFF


### PR DESCRIPTION
- use a single function to open the same file for the same format
- write extensible data if file format is extended
- open file once for each submitChunk
- use only SDL_RWops functions for file access

It's not creating working files. It creates readable headers for non-extended encodings (at least VLC recognizes the format, but is not able to load the files). Warframe uses ADPCM and WMAUDIO2. I unfortunately havn't found refernce files for these formats to trim the dumping to produce working wma files

Feedback and tips are very welcome