### PR TITLE
Don't override user-defined SDL2 variables.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,9 @@ if(FFMPEG)
 endif(FFMPEG)
 
 # SDL2 Dependency
-find_package(SDL2 CONFIG)
+if (NOT DEFINED SDL2_INCLUDE_DIRS AND NOT DEFINED SDL2_LIBRARIES)
+	find_package(SDL2 CONFIG)
+endif()
 if (TARGET SDL2::SDL2)
 	message(STATUS "using TARGET SDL2::SDL2")
 	target_link_libraries(FAudio PUBLIC SDL2::SDL2)


### PR DESCRIPTION
On my system, SDL2's CMake config file unconditionally sets
`SDL2_INCLUDE_DIRS` and `SDL2_LIBRARIES`. This causes problems building
FAudio reproducibly when SDL2 is installed locally.