### PR TITLE
Fix stb.h warnings

### DIFF
--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -29,8 +29,6 @@
 
 /* RNG */
 
-#define STB_EXTERN
-#define STB_DEFINE
 #include "stb.h"
 #define FACT_INTERNAL_rng() ((float) stb_frand())
 

--- a/src/stb.h
+++ b/src/stb.h
@@ -214,6 +214,10 @@ CREDITS
 #define memcpy FAudio_memcpy
 #endif
 
+#define STB_EXTERN
+#define STB_DEFINE
+#include <stddef.h>
+
 //////////////////////////////////////////////////////////////////////////////
 //
 //                         Miscellany

--- a/src/stb.h
+++ b/src/stb.h
@@ -296,7 +296,7 @@ unsigned int  stb_randLCG(void)
 // public domain Mersenne Twister by Michael Brundage
 #define STB__MT_LEN       624
 
-int stb__mt_index = STB__MT_LEN*sizeof(int)+1;
+unsigned int stb__mt_index = STB__MT_LEN*sizeof(int)+1;
 unsigned int stb__mt_buffer[STB__MT_LEN];
 
 void stb_srand(unsigned int seed)
@@ -320,7 +320,7 @@ void stb_srand(unsigned int seed)
 unsigned int stb_rand()
 {
    unsigned int  * b = stb__mt_buffer;
-   int idx = stb__mt_index;
+   unsigned int idx = stb__mt_index;
    unsigned int  s,r;
    int i;
 	


### PR DESCRIPTION
fix signed/unsigned comparison warning in stb.h

also move the defines into stb.h header itself (makes the clang code model happy and stb.h can be used without need to define stuff)