### PR TITLE
showriffheader: fix when fmt subchunk-size of 16

### DIFF
--- a/utils/showriffheader/showriffheader.cpp
+++ b/utils/showriffheader/showriffheader.cpp
@@ -114,7 +114,6 @@ uint32_t load_data(const char *filename)
 	fseek(hFile, 0, SEEK_SET);
 
 	uint32_t chunkID;
-	uint32_t dwChunkSize;
 	uint32_t dwChunkPosition = 0;
 
 	// search for 'RIFF' chunk
@@ -152,6 +151,7 @@ uint32_t load_data(const char *filename)
 				  << uint32_to_charstr(format) << std::endl;
 	}
 	uint32_t fmt_chunk_start = dwChunkPosition;
+	uint32_t fmt_chunk_size  = 0;
 	{ /* fmt sub-chunk 24 */
 		if (fread(&chunkID, sizeof(uint32_t), 1, hFile) < 1)
 			throw std::runtime_error("can't read fmt chunkID");
@@ -163,11 +163,11 @@ uint32_t load_data(const char *filename)
 			std::cout << "expected chunkID 'fmt '" << std::endl;
 			return 1;
 		}
-		if (fread(&dwChunkSize, sizeof(uint32_t), 1, hFile) < 1)
+		if (fread(&fmt_chunk_size, sizeof(uint32_t), 1, hFile) < 1)
 			throw std::runtime_error("can't read fmt  chunkSize");
 		dwChunkPosition += sizeof (uint32_t);
 		std::cout << "ChunkSize:        "
-				  << uint32_to_charstr(dwChunkSize) << std::endl;
+				  << uint32_to_charstr(fmt_chunk_size) << std::endl;
 		uint16_t audio_format;
 		if (fread(&audio_format, sizeof(uint16_t), 1, hFile) < 1)
 			throw std::runtime_error("can't read fmt  AudioFormat");
@@ -226,6 +226,7 @@ uint32_t load_data(const char *filename)
 				  << uint16_to_charstr(BitsPerSample) << std::endl;
 	}
 	/* in case of extensible audio format write the additional data to the file */
+	if (fmt_chunk_size > 16)
 	{
 		std::cout << "fmt chunk position: " << dwChunkPosition - fmt_chunk_start << std::endl;
 		uint16_t cb_size;


### PR DESCRIPTION
Fix the case when fmt subchunk-size == 16, then there is no cbSize
entry, instead the data subchunk can immediately start.

Encountered when parsing a PCM formated wav file
```
showriffheader FA_fmt_0x0001_Ensoniq-ESQ-1-Sympy-C4.wav
found 'RIFF' at: 0
RIFF:             |RIFF|52.49.46.46|0x46464952|1179011410|
ChunkSize:        |*   |2a.8c.0f.00|0x000f8c2a|   1018922|
Format:           |WAVE|57.41.56.45|0x45564157|1163280727|
fmt:              |fmt |66.6d.74.20|0x20746d66| 544501094|
ChunkSize:        |    |10.00.00.00|0x00000010|        16|
fmt AudioFormat:  |    |01.00      |    0x0001|         1| FAUDIO_FORMAT_PCM
fmt NumChannels:  |    |02.00      |    0x0002|         2|
fmt SampleRate:   |D   |44.ac.00.00|0x0000ac44|     44100|
fmt ByteRate:     |    |10.b1.02.00|0x0002b110|    176400|
fmt BloackAlign:  |    |04.00      |    0x0004|         4|
fmt BitsPerSample:|    |10.00      |    0x0010|        16|
data chunk position: 32
data:             |data|64.61.74.61|0x61746164|1635017060|
data chunkSize:   |    |d8.8a.0f.00|0x000f8ad8|   1018584|
unknown chunkID at position: 1018624
unhandled chunk:  |LIST|4c.49.53.54|0x5453494c|1414744396|
success
```