### PR TITLE
Wavebank shouldn't destroy the parentCue as it's content may already have been destroyed

### DIFF
--- a/src/FACT.c
+++ b/src/FACT.c
@@ -1297,15 +1297,7 @@ uint32_t FACTWaveBank_Destroy(FACTWaveBank *pWaveBank)
 	while (pWaveBank->waveList != NULL)
 	{
 		wave = (FACTWave*) pWaveBank->waveList->entry;
-		if (wave->parentCue != NULL)
-		{
-			/* Destroying this Cue destroys the Wave */
-			FACTCue_Destroy(wave->parentCue);
-		}
-		else
-		{
-			FACTWave_Destroy(wave);
-		}
+		FACTWave_Destroy(wave);
 	}
 
 	if (pWaveBank->parentEngine != NULL)


### PR DESCRIPTION
When FACT_INTERNAL_CreateSound creates a Wave, it assigns the Cue to wave->parentCue.  If you then call FACT_CueDestroy on the Cue, assume a Play/Stop/Destroy. Later when the WaveBank is destroyed, it loops the waves and checks wave->parentCue, however this is no longer valid and causes a crash when its attempts to destroy it again.

There might be better way to clear wave->parentCue when FACT_CueDestroy is called, happy for comments.