### PR TITLE
dump: remove extra WMAUDIO2 handling in file name creation

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -2753,11 +2753,6 @@ static inline FAudioIOStreamOut *DumpVoices_fopen(
 				(const FAudioWaveFormatExtensible*) format;
 		format_ex_tag = (uint16_t) (format_ex->SubFormat.Data1);
 	}
-	if (format->wFormatTag == FAUDIO_FORMAT_WMAUDIO2)
-	{
-		format_tag = FAUDIO_FORMAT_EXTENSIBLE;
-		format_ex_tag = FAUDIO_FORMAT_WMAUDIO2;
-	}
 	FAudio_snprintf(
 		loc,
 		sizeof(loc),


### PR DESCRIPTION
This special handling is not needed anymore as WMAUDIO2 is converted to
FAUDIO_FORMAT_EXTENSIBLE by FAudio_CreateSourceVoice().