### PR TITLE
Playing a Cue should remove the FACT_STATE_PREPARED flag

### DIFF
--- a/src/FACT.c
+++ b/src/FACT.c
@@ -2274,7 +2274,8 @@ uint32_t FACTCue_Play(FACTCue *pCue)
 	pCue->state |= FACT_STATE_PLAYING;
 	pCue->state &= ~(
 		FACT_STATE_PAUSED |
-		FACT_STATE_STOPPED
+		FACT_STATE_STOPPED |
+		FACT_STATE_PREPARED
 	);
 	pCue->start = FAudio_timems();
 


### PR DESCRIPTION
Pac-man Museum demo requires the GetState returns PLAYING without the PREPARED flag.