### PR TITLE
Handle negative zero rt60_ms values.

### DIFF
--- a/src/FAudioFX_reverb.c
+++ b/src/FAudioFX_reverb.c
@@ -150,14 +150,7 @@ static inline void DspDelay_Destroy(DspDelay *filter, FAudioFreeFunc pFree)
 
 static inline float DspComb_FeedbackFromRT60(DspDelay *delay, float rt60_ms)
 {
-	float exponent;
-
-	if (rt60_ms == 0)
-	{
-		return 0;
-	}
-
-	exponent = (
+	float exponent = (
 		(-3.0f * delay->delay * 1000.0f) /
 		(delay->sampleRate * rt60_ms)
 	);
@@ -685,7 +678,7 @@ static inline void DspReverb_SetParameters(
 			);
 			comb->comb_feedback_gain = DspComb_FeedbackFromRT60(
 				&comb->comb_delay,
-				params->DecayTime * 1000.0f
+				FAudio_max(params->DecayTime, FAUDIOFX_REVERB_MIN_DECAY_TIME) * 1000.0f
 			);
 
 			/* High/Low shelving */


### PR DESCRIPTION
Dragon Quest Builders 2 audio is broken because is uses a DecayTime of -0.f, and that causes infinite gain and NaN values creeping up the reverb buffer.

This could also be done in some XAPO_PROCESS_BUFFER_PARAMETERS params validation code, or before calling / within DspReverb_SetParameters.