### PR TITLE
Fix XAUDIO2_EFFECT_DESCRIPTOR::OutputChannels name

### DIFF
--- a/cpp/xaudio2.cpp
+++ b/cpp/xaudio2.cpp
@@ -376,7 +376,7 @@ static FAudioEffectChain *wrap_effect_chain(const XAUDIO2_EFFECT_CHAIN *x_chain)
 	{
 		f_chain->pEffectDescriptors[i].InitialState = x_chain->pEffectDescriptors[i].InitialState;
 		f_chain->pEffectDescriptors[i].OutputChannels =
-			x_chain->pEffectDescriptors[i].OutputChannel;
+			x_chain->pEffectDescriptors[i].OutputChannels;
 		f_chain->pEffectDescriptors[i].pEffect =
 			wrap_xapo_effect(x_chain->pEffectDescriptors[i].pEffect);
 	}

--- a/cpp/xaudio2.h
+++ b/cpp/xaudio2.h
@@ -56,7 +56,7 @@ typedef struct XAUDIO2_VOICE_SENDS {
 typedef struct XAUDIO2_EFFECT_DESCRIPTOR {
 	IUnknown *pEffect;
 	BOOL InitialState;
-	UINT32  OutputChannel;
+	UINT32  OutputChannels;
 } XAUDIO2_EFFECT_DESCRIPTOR;
 
 typedef struct XAUDIO2_EFFECT_CHAIN {


### PR DESCRIPTION
This is the definition of `XAUDIO2_EFFECT_DESCRIPTOR` in my Windows 8.1 SDK:

```cpp
// Used in XAUDIO2_EFFECT_CHAIN below
typedef struct XAUDIO2_EFFECT_DESCRIPTOR
{
    IUnknown* pEffect;                  // Pointer to the effect object's IUnknown interface.
    BOOL InitialState;                  // TRUE if the effect should begin in the enabled state.
    UINT32 OutputChannels;              // How many output channels the effect should produce.
} XAUDIO2_EFFECT_DESCRIPTOR;
```