### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,9 @@ endif()
 # utils/ Folder
 if(BUILD_UTILS)
 	enable_language(CXX)
-
+	set(CMAKE_CXX_STANDARD 11)
+	set(CMAKE_CXX_EXTENSIONS OFF)
+  
 	# Shared ImGui Framework
 	add_library(uicommon STATIC
 		utils/uicommon/FAudioUI_main.cpp


### PR DESCRIPTION
Utils target requires CX11.  Tell cmake.

```
[ 66%] Building CXX object CMakeFiles/showriffheader.dir/utils/showriffheader/showriffheader.cpp.o
In file included from /usr/include/c++/4.8.2/array:35:0,
                 from /tmp/FAudio/utils/showriffheader/showriffheader.cpp:9:
/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:11:1: error: ‘array’ in namespace ‘std’ does not name a type
 std::array<uint8_t, 2> fill_char_buffer(const uint16_t x)
 ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:18:1: error: ‘array’ in namespace ‘std’ does not name a type
 std::array<uint8_t, 4> fill_char_buffer(const uint32_t x)
 ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp: In function ‘std::string uint16_to_charstr(uint16_t)’:
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:51:2: error: ‘array’ is not a member of ‘std’
  std::array<uint8_t, 2> buf = fill_char_buffer(x);
  ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:51:20: error: expected primary-expression before ‘,’ token
  std::array<uint8_t, 2> buf = fill_char_buffer(x);
                    ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:51:25: error: ‘buf’ was not declared in this scope
  std::array<uint8_t, 2> buf = fill_char_buffer(x);
                         ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:51:49: error: ‘fill_char_buffer’ was not declared in this scope
  std::array<uint8_t, 2> buf = fill_char_buffer(x);
                                                 ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp: In function ‘std::string uint32_to_charstr(uint32_t)’:
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:73:2: error: ‘array’ is not a member of ‘std’
  std::array<uint8_t, 4> buf = fill_char_buffer(x);
  ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:73:20: error: expected primary-expression before ‘,’ token
  std::array<uint8_t, 4> buf = fill_char_buffer(x);
                    ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:73:25: error: ‘buf’ was not declared in this scope
  std::array<uint8_t, 4> buf = fill_char_buffer(x);
                         ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:73:49: error: ‘fill_char_buffer’ was not declared in this scope
  std::array<uint8_t, 4> buf = fill_char_buffer(x);
                                                 ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp: In function ‘uint32_t load_data(const char*)’:
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:143:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read RIFF filesize");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:148:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read RIFF format");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:157:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt chunkID");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:167:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt  chunkSize");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:173:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt  AudioFormat");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:175:8: error: ‘audio_format_str’ does not name a type
   auto audio_format_str = [](const uint16_t format)
        ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:197:46: error: ‘audio_format_str’ was not declared in this scope
       << " " << audio_format_str(audio_format) << std::endl;
                                              ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:200:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt  NumChannels");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:206:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt  SampleRate");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:211:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt  ByteRate");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:217:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt  BloackAlign");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:223:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt  BitsPerSample");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:234:10: error: ‘runtime_error’ is not a member of ‘std’
    throw std::runtime_error("can't read fmt cbSize");
          ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:242:11: error: ‘runtime_error’ is not a member of ‘std’
     throw std::runtime_error("can't read fmt ex ValidBitsPerSample");
           ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:248:11: error: ‘runtime_error’ is not a member of ‘std’
     throw std::runtime_error("can't read fmt ex dwChannelMask");
           ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:254:11: error: ‘runtime_error’ is not a member of ‘std’
     throw std::runtime_error("can't read fmt ex Data1");
           ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:260:11: error: ‘runtime_error’ is not a member of ‘std’
     throw std::runtime_error("can't read fmt ex Data2");
           ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:266:11: error: ‘runtime_error’ is not a member of ‘std’
     throw std::runtime_error("can't read fmt ex Data3");
           ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:272:11: error: ‘runtime_error’ is not a member of ‘std’
     throw std::runtime_error("can't read fmt ex Data4");
           ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:285:12: error: ‘runtime_error’ is not a member of ‘std’
      throw std::runtime_error("can't read fmt ex padding");
            ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:296:7: error: ‘print_sub_chunk’ does not name a type
  auto print_sub_chunk = [&]()
       ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:345:19: error: ‘print_sub_chunk’ was not declared in this scope
   print_sub_chunk();
                   ^
/tmp/FAudio/utils/showriffheader/showriffheader.cpp:347:19: error: ‘print_sub_chunk’ was not declared in this scope
   print_sub_chunk();
                   ^
make[2]: *** [CMakeFiles/showriffheader.dir/utils/showriffheader/showriffheader.cpp.o] Error 1
make[1]: *** [CMakeFiles/showriffheader.dir/all] Error 2
make: *** [all] Error 2
```