### PR TITLE
Protect caches

### DIFF
--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -636,6 +636,20 @@ static inline void FAudio_INTERNAL_FilterVoice(
 	LOG_FUNC_EXIT(audio)
 }
 
+static void FAudio_INTERNAL_ResizeEffectChainCache(FAudio *audio, uint32_t samples)
+{
+	LOG_FUNC_ENTER(audio)
+	if (samples > audio->effectChainSamples)
+	{
+		audio->effectChainSamples = samples;
+		audio->effectChainCache = (float*) audio->pRealloc(
+			audio->effectChainCache,
+			sizeof(float) * audio->effectChainSamples
+		);
+	}
+	LOG_FUNC_EXIT(audio)
+}
+
 static inline float *FAudio_INTERNAL_ProcessEffectChain(
 	FAudioVoice *voice,
 	float *buffer,
@@ -1392,20 +1406,6 @@ void FAudio_INTERNAL_ResizeResampleCache(FAudio *audio, uint32_t samples)
 	}
 	FAudio_PlatformUnlockMutex(audio->sourceLock);
 	LOG_MUTEX_UNLOCK(audio, audio->sourceLock)
-	LOG_FUNC_EXIT(audio)
-}
-
-void FAudio_INTERNAL_ResizeEffectChainCache(FAudio *audio, uint32_t samples)
-{
-	LOG_FUNC_ENTER(audio)
-	if (samples > audio->effectChainSamples)
-	{
-		audio->effectChainSamples = samples;
-		audio->effectChainCache = (float*) audio->pRealloc(
-			audio->effectChainCache,
-			sizeof(float) * audio->effectChainSamples
-		);
-	}
 	LOG_FUNC_EXIT(audio)
 }
 

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -1362,6 +1362,8 @@ void FAudio_INTERNAL_UpdateEngine(FAudio *audio, float *output)
 void FAudio_INTERNAL_ResizeDecodeCache(FAudio *audio, uint32_t samples)
 {
 	LOG_FUNC_ENTER(audio)
+	FAudio_PlatformLockMutex(audio->sourceLock);
+	LOG_MUTEX_LOCK(audio, audio->sourceLock)
 	if (samples > audio->decodeSamples)
 	{
 		audio->decodeSamples = samples;
@@ -1370,12 +1372,16 @@ void FAudio_INTERNAL_ResizeDecodeCache(FAudio *audio, uint32_t samples)
 			sizeof(float) * audio->decodeSamples
 		);
 	}
+	FAudio_PlatformUnlockMutex(audio->sourceLock);
+	LOG_MUTEX_UNLOCK(audio, audio->sourceLock)
 	LOG_FUNC_EXIT(audio)
 }
 
 void FAudio_INTERNAL_ResizeResampleCache(FAudio *audio, uint32_t samples)
 {
 	LOG_FUNC_ENTER(audio)
+	FAudio_PlatformLockMutex(audio->sourceLock);
+	LOG_MUTEX_LOCK(audio, audio->sourceLock)
 	if (samples > audio->resampleSamples)
 	{
 		audio->resampleSamples = samples;
@@ -1384,6 +1390,8 @@ void FAudio_INTERNAL_ResizeResampleCache(FAudio *audio, uint32_t samples)
 			sizeof(float) * audio->resampleSamples
 		);
 	}
+	FAudio_PlatformUnlockMutex(audio->sourceLock);
+	LOG_MUTEX_UNLOCK(audio, audio->sourceLock)
 	LOG_FUNC_EXIT(audio)
 }
 

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -494,7 +494,6 @@ void FAudio_INTERNAL_InsertSubmixSorted(
 void FAudio_INTERNAL_UpdateEngine(FAudio *audio, float *output);
 void FAudio_INTERNAL_ResizeDecodeCache(FAudio *audio, uint32_t size);
 void FAudio_INTERNAL_ResizeResampleCache(FAudio *audio, uint32_t size);
-void FAudio_INTERNAL_ResizeEffectChainCache(FAudio *audio, uint32_t samples);
 void FAudio_INTERNAL_AllocEffectChain(
 	FAudioVoice *voice,
 	const FAudioEffectChain *pEffectChain


### PR DESCRIPTION
I figured out the Banished crash!! The game creates new source voices in one thread while the engine thread is mixing sources. This would cause the decodeCache to be reallocated near the end of FAudio_CreateSourceVoice, while the buffer was still in use (e.g. being written into by the gst decoding code). This patchset moves the source mutex unlocking around each callback invocation, instead of around the entire mixing procedure (see 0a7e525702cd21cfee39b9816a152a1ab25ae538), and then takes the lock when it tries to realloc the buffer.

The third patch was just something I noticed while working on this code; feel free to ignore it if it's not worth the noise.