### PR TITLE
Provide SSE generic mixing function

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -1221,7 +1221,7 @@ uint32_t FAudioVoice_SetOutputVoices(
 			}
 			else
 			{
-				voice->sendMix[i] = FAudio_INTERNAL_Mix_Generic_Scalar;
+				voice->sendMix[i] = FAudio_INTERNAL_Mix_Generic;
 			}
 		}
 		else if (voice->outputChannels == 2)
@@ -1244,12 +1244,12 @@ uint32_t FAudioVoice_SetOutputVoices(
 			}
 			else
 			{
-				voice->sendMix[i] = FAudio_INTERNAL_Mix_Generic_Scalar;
+				voice->sendMix[i] = FAudio_INTERNAL_Mix_Generic;
 			}
 		}
 		else
 		{
-			voice->sendMix[i] = FAudio_INTERNAL_Mix_Generic_Scalar;
+			voice->sendMix[i] = FAudio_INTERNAL_Mix_Generic;
 		}
 
 		if (pSendList->pSends[i].Flags & FAUDIO_SEND_USEFILTER)

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -1023,11 +1023,9 @@ sendwork:
 			mixed,
 			voice->outputChannels,
 			oChan,
-			voice->volume,
 			finalSamples,
 			stream,
-			voice->channelVolume,
-			voice->sendCoefficients[i]
+			voice->mixCoefficients[i]
 		);
 
 		if (voice->sends.pSends[i].Flags & FAUDIO_SEND_USEFILTER)
@@ -1153,11 +1151,9 @@ static void FAudio_INTERNAL_MixSubmix(FAudioSubmixVoice *voice)
 			resampled,
 			voice->outputChannels,
 			oChan,
-			1.0f,
 			finalSamples,
 			stream,
-			voice->channelVolume,
-			voice->sendCoefficients[i]
+			voice->mixCoefficients[i]
 		);
 
 		if (voice->sends.pSends[i].Flags & FAUDIO_SEND_USEFILTER)

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -660,6 +660,8 @@ extern void (*FAudio_INTERNAL_Amplify)(
 	float volume
 );
 
+extern FAudioMixCallback FAudio_INTERNAL_Mix_Generic;
+
 #define MIX_FUNC(type) \
 	extern void FAudio_INTERNAL_Mix_##type##_Scalar( \
 		uint32_t toMix, \

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -249,10 +249,8 @@ typedef void (FAUDIOCALL * FAudioMixCallback)(
 	uint32_t toMix,
 	uint32_t srcChans,
 	uint32_t dstChans,
-	float baseVolume,
 	float *restrict srcData,
 	float *restrict dstData,
-	float *restrict channelVolume,
 	float *restrict coefficients
 );
 
@@ -396,6 +394,7 @@ struct FAudioVoice
 
 	FAudioVoiceSends sends;
 	float **sendCoefficients;
+	float **mixCoefficients;
 	FAudioMixCallback *sendMix;
 	FAudioFilterParameters *sendFilter;
 	FAudioFilterState **sendFilterState;
@@ -666,10 +665,8 @@ extern void (*FAudio_INTERNAL_Amplify)(
 		uint32_t toMix, \
 		uint32_t srcChans, \
 		uint32_t dstChans, \
-		float baseVolume, \
 		float *restrict srcData, \
 		float *restrict dstData, \
-		float *restrict channelVolume, \
 		float *restrict coefficients \
 	);
 MIX_FUNC(Generic)

--- a/src/FAudio_internal_simd.c
+++ b/src/FAudio_internal_simd.c
@@ -1282,10 +1282,8 @@ void FAudio_INTERNAL_Mix_Generic_Scalar(
 	uint32_t toMix,
 	uint32_t srcChans,
 	uint32_t dstChans,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i, co, ci;
@@ -1296,8 +1294,6 @@ void FAudio_INTERNAL_Mix_Generic_Scalar(
 		{
 			dst[co] += (
 				src[ci] *
-				channelVolume[ci] *
-				baseVolume *
 				coefficients[co * srcChans + ci]
 			);
 		}
@@ -1308,18 +1304,15 @@ void FAudio_INTERNAL_Mix_1in_1out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolume = baseVolume * channelVolume[0] * coefficients[0];
 	for (i = 0; i < toMix; i += 1, src += 1, dst += 1)
 	{
 		/* Base source data, combined with the coefficients */
-		dst[0] += src[0] * totalVolume;
+		dst[0] += src[0] * coefficients[0];
 	}
 }
 
@@ -1327,22 +1320,15 @@ void FAudio_INTERNAL_Mix_1in_2out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolume = baseVolume * channelVolume[0];
 	for (i = 0; i < toMix; i += 1, src += 1, dst += 2)
 	{
-		/* Base source data... */
-		const float sample = src[0] * totalVolume;
-
-		/* ... combined with the coefficients. */
-		dst[0] += sample * coefficients[0];
-		dst[1] += sample * coefficients[1];
+		dst[0] += src[0] * coefficients[0];
+		dst[1] += src[0] * coefficients[1];
 	}
 }
 
@@ -1350,26 +1336,19 @@ void FAudio_INTERNAL_Mix_1in_6out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolume = baseVolume * channelVolume[0];
 	for (i = 0; i < toMix; i += 1, src += 1, dst += 6)
 	{
-		/* Base source data... */
-		const float sample = src[0] * totalVolume;
-
-		/* ... combined with the coefficients. */
-		dst[0] += sample * coefficients[0];
-		dst[1] += sample * coefficients[1];
-		dst[2] += sample * coefficients[2];
-		dst[3] += sample * coefficients[3];
-		dst[4] += sample * coefficients[4];
-		dst[5] += sample * coefficients[5];
+		dst[0] += src[0] * coefficients[0];
+		dst[1] += src[0] * coefficients[1];
+		dst[2] += src[0] * coefficients[2];
+		dst[3] += src[0] * coefficients[3];
+		dst[4] += src[0] * coefficients[4];
+		dst[5] += src[0] * coefficients[5];
 	}
 }
 
@@ -1377,28 +1356,21 @@ void FAudio_INTERNAL_Mix_1in_8out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolume = baseVolume * channelVolume[0];
 	for (i = 0; i < toMix; i += 1, src += 1, dst += 8)
 	{
-		/* Base source data... */
-		const float sample = src[0] * totalVolume;
-
-		/* ... combined with the coefficients. */
-		dst[0] += sample * coefficients[0];
-		dst[1] += sample * coefficients[1];
-		dst[2] += sample * coefficients[2];
-		dst[3] += sample * coefficients[3];
-		dst[4] += sample * coefficients[4];
-		dst[5] += sample * coefficients[5];
-		dst[6] += sample * coefficients[6];
-		dst[7] += sample * coefficients[7];
+		dst[0] += src[0] * coefficients[0];
+		dst[1] += src[0] * coefficients[1];
+		dst[2] += src[0] * coefficients[2];
+		dst[3] += src[0] * coefficients[3];
+		dst[4] += src[0] * coefficients[4];
+		dst[5] += src[0] * coefficients[5];
+		dst[6] += src[0] * coefficients[6];
+		dst[7] += src[0] * coefficients[7];
 	}
 }
 
@@ -1406,21 +1378,17 @@ void FAudio_INTERNAL_Mix_2in_1out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolumeL = baseVolume * channelVolume[0] * coefficients[0];
-	float totalVolumeR = baseVolume * channelVolume[1] * coefficients[1];
 	for (i = 0; i < toMix; i += 1, src += 2, dst += 1)
 	{
 		/* Base source data, combined with the coefficients */
 		dst[0] += (
-			(src[0] * totalVolumeL) +
-			(src[1] * totalVolumeR)
+			(src[0] * coefficients[0]) +
+			(src[1] * coefficients[1])
 		);
 	}
 }
@@ -1429,29 +1397,20 @@ void FAudio_INTERNAL_Mix_2in_2out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolumeL = baseVolume * channelVolume[0];
-	float totalVolumeR = baseVolume * channelVolume[1];
 	for (i = 0; i < toMix; i += 1, src += 2, dst += 2)
 	{
-		/* Base source data... */
-		const float left = src[0] * totalVolumeL;
-		const float right = src[1] * totalVolumeR;
-
-		/* ... combined with the coefficients. */
 		dst[0] += (
-			(left * coefficients[0]) +
-			(right * coefficients[1])
+			(src[0] * coefficients[0]) +
+			(src[1] * coefficients[1])
 		);
 		dst[1] += (
-			(left * coefficients[2]) +
-			(right * coefficients[3])
+			(src[0] * coefficients[2]) +
+			(src[1] * coefficients[3])
 		);
 	}
 }
@@ -1460,45 +1419,36 @@ void FAudio_INTERNAL_Mix_2in_6out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolumeL = baseVolume * channelVolume[0];
-	float totalVolumeR = baseVolume * channelVolume[1];
 	for (i = 0; i < toMix; i += 1, src += 2, dst += 6)
 	{
-		/* Base source data... */
-		const float left = src[0] * totalVolumeL;
-		const float right = src[1] * totalVolumeR;
-
-		/* ... combined with the coefficients. */
 		dst[0] += (
-			(left * coefficients[0]) +
-			(right * coefficients[1])
+			(src[0] * coefficients[0]) +
+			(src[1] * coefficients[1])
 		);
 		dst[1] += (
-			(left * coefficients[2]) +
-			(right * coefficients[3])
+			(src[0] * coefficients[2]) +
+			(src[1] * coefficients[3])
 		);
 		dst[2] += (
-			(left * coefficients[4]) +
-			(right * coefficients[5])
+			(src[0] * coefficients[4]) +
+			(src[1] * coefficients[5])
 		);
 		dst[3] += (
-			(left * coefficients[6]) +
-			(right * coefficients[7])
+			(src[0] * coefficients[6]) +
+			(src[1] * coefficients[7])
 		);
 		dst[4] += (
-			(left * coefficients[8]) +
-			(right * coefficients[9])
+			(src[0] * coefficients[8]) +
+			(src[1] * coefficients[9])
 		);
 		dst[5] += (
-			(left * coefficients[10]) +
-			(right * coefficients[11])
+			(src[0] * coefficients[10]) +
+			(src[1] * coefficients[11])
 		);
 	}
 }
@@ -1507,53 +1457,44 @@ void FAudio_INTERNAL_Mix_2in_8out_Scalar(
 	uint32_t toMix,
 	uint32_t UNUSED1,
 	uint32_t UNUSED2,
-	float baseVolume,
 	float *restrict src,
 	float *restrict dst,
-	float *restrict channelVolume,
 	float *restrict coefficients
 ) {
 	uint32_t i;
-	float totalVolumeL = baseVolume * channelVolume[0];
-	float totalVolumeR = baseVolume * channelVolume[1];
 	for (i = 0; i < toMix; i += 1, src += 2, dst += 8)
 	{
-		/* Base source data... */
-		const float left = src[0] * totalVolumeL;
-		const float right = src[1] * totalVolumeR;
-
-		/* ... combined with the coefficients. */
 		dst[0] += (
-			(left * coefficients[0]) +
-			(right * coefficients[1])
+			(src[0] * coefficients[0]) +
+			(src[1] * coefficients[1])
 		);
 		dst[1] += (
-			(left * coefficients[2]) +
-			(right * coefficients[3])
+			(src[0] * coefficients[2]) +
+			(src[1] * coefficients[3])
 		);
 		dst[2] += (
-			(left * coefficients[4]) +
-			(right * coefficients[5])
+			(src[0] * coefficients[4]) +
+			(src[1] * coefficients[5])
 		);
 		dst[3] += (
-			(left * coefficients[6]) +
-			(right * coefficients[7])
+			(src[0] * coefficients[6]) +
+			(src[1] * coefficients[7])
 		);
 		dst[4] += (
-			(left * coefficients[8]) +
-			(right * coefficients[9])
+			(src[0] * coefficients[8]) +
+			(src[1] * coefficients[9])
 		);
 		dst[5] += (
-			(left * coefficients[10]) +
-			(right * coefficients[11])
+			(src[0] * coefficients[10]) +
+			(src[1] * coefficients[11])
 		);
 		dst[6] += (
-			(left * coefficients[12]) +
-			(right * coefficients[13])
+			(src[0] * coefficients[12]) +
+			(src[1] * coefficients[13])
 		);
 		dst[7] += (
-			(left * coefficients[14]) +
-			(right * coefficients[15])
+			(src[0] * coefficients[14]) +
+			(src[1] * coefficients[15])
 		);
 	}
 }


### PR DESCRIPTION
The first commit removes a lot of the multiplications from the mixing functions. That speeds things up a little bit, but not very noticeably.

The second commit uses SSE to perform the attenuation, while we have at least four source channels remaining to pull from. It significantly improves performance and fixes the underruns for me in Beyond Two Souls. The game is kind of a special case in that it does a lot of mixing from 8-channel sources, which will hit the fast path very often.