### PR TITLE
Add workaround for emscripten buffer size requirements

### DIFF
--- a/src/FAudio_platform_sdl2.c
+++ b/src/FAudio_platform_sdl2.c
@@ -117,6 +117,16 @@ void FAudio_PlatformInit(
 		changes = SDL_AUDIO_ALLOW_SAMPLES_CHANGE;
 	}
 
+	/* FIXME: SDL bug!
+	 * <INSERT INFORMED COMMENT ABOUT THE BUG>
+	 *
+	 * https://bugzilla.libsdl.org/show_bug.cgi?id=5136
+	 */
+	if (SDL_strcmp(SDL_GetCurrentAudioDriver(), "emscripten") == 0)
+	{
+		want.samples = 512;
+	}
+
 	/* Open the device (or at least try to) */
 iosretry:
 	device = SDL_OpenAudioDevice(


### PR DESCRIPTION
Added a check for Emscripten so we can override the `want.samples` value. That said, I don't really understand how this works, so I figured it'd be best if you wrote the comment. 😅 