### PR TITLE
Resample cache locks

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -2830,20 +2830,16 @@ uint32_t FAudioSourceVoice_SetSourceSampleRate(
 		voice->sends.pSends[0].pOutputVoice->master.inputSampleRate :
 		voice->sends.pSends[0].pOutputVoice->mix.inputSampleRate;
 
-	FAudio_PlatformUnlockMutex(voice->sendLock);
-	LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
-
-	/* Resize resample cache */
 	newResampleSamples = (uint32_t) (FAudio_ceil(
 		(double) voice->audio->updateSize *
 		(double) outSampleRate /
 		(double) voice->audio->master->master.inputSampleRate
 	));
-	FAudio_INTERNAL_ResizeResampleCache(
-		voice->audio,
-		newResampleSamples * voice->src.format->nChannels
-	);
 	voice->src.resampleSamples = newResampleSamples;
+
+	FAudio_PlatformUnlockMutex(voice->sendLock);
+	LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
 	LOG_API_EXIT(voice->audio)
 	return 0;
 }

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -815,9 +815,6 @@ static void FAudio_INTERNAL_MixSource(FAudioSourceVoice *voice)
 	/* ... fixed to int, truncating extra fraction from rounding. */
 	toDecode >>= FIXED_PRECISION;
 
-	FAudio_PlatformLockMutex(voice->src.bufferLock);
-	LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
-
 	/* First voice callback */
 	if (	voice->src.callback != NULL &&
 		voice->src.callback->OnVoiceProcessingPassStart != NULL	)
@@ -839,6 +836,9 @@ static void FAudio_INTERNAL_MixSource(FAudioSourceVoice *voice)
 		FAudio_PlatformLockMutex(voice->sendLock);
 		LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
 	}
+
+	FAudio_PlatformLockMutex(voice->src.bufferLock);
+	LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 
 	/* Nothing to do? */
 	if (voice->src.bufferList == NULL)
@@ -897,6 +897,9 @@ static void FAudio_INTERNAL_MixSource(FAudioSourceVoice *voice)
 	if (	voice->src.callback != NULL &&
 		voice->src.callback->OnVoiceProcessingPassEnd != NULL)
 	{
+		FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+		LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
 		FAudio_PlatformUnlockMutex(voice->sendLock);
 		LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
 
@@ -912,6 +915,9 @@ static void FAudio_INTERNAL_MixSource(FAudioSourceVoice *voice)
 
 		FAudio_PlatformLockMutex(voice->sendLock);
 		LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+		FAudio_PlatformLockMutex(voice->src.bufferLock);
+		LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 	}
 
 	/* Nothing to resample? */

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -493,7 +493,6 @@ void FAudio_INTERNAL_InsertSubmixSorted(
 );
 void FAudio_INTERNAL_UpdateEngine(FAudio *audio, float *output);
 void FAudio_INTERNAL_ResizeDecodeCache(FAudio *audio, uint32_t size);
-void FAudio_INTERNAL_ResizeResampleCache(FAudio *audio, uint32_t size);
 void FAudio_INTERNAL_AllocEffectChain(
 	FAudioVoice *voice,
 	const FAudioEffectChain *pEffectChain


### PR DESCRIPTION
First commit moves allocation of the resample cache into the mixer code, like you suggested (#215).

Second commit mirrors the submix voice mixing, where it holds sendLock through the whole mixing procedure. My motivation here was to protect access to resampleSamples, which otherwise could change mid-mix (I guess it still can via callbacks...).

Please review carefully, there's a lot of locks going on here, and it's possible I made a mistake. One open question is whether we should hold the bufferLock while calling the callbacks. We currently do, so I didn't change that, but I wonder if we should drop the lock?