### PR TITLE
Correct packing for structure FACTRuntimeParameters

### DIFF
--- a/include/FACT.h
+++ b/include/FACT.h
@@ -101,20 +101,6 @@ typedef void (FACTCALL * FACTNotificationCallback)(
 	const FACTNotification *pNotification
 );
 
-typedef struct FACTRuntimeParameters
-{
-	uint32_t lookAheadTime;
-	void *pGlobalSettingsBuffer;
-	uint32_t globalSettingsBufferSize;
-	uint32_t globalSettingsFlags;
-	uint32_t globalSettingsAllocAttributes;
-	FACTFileIOCallbacks fileIOCallbacks;
-	FACTNotificationCallback fnNotificationCallback;
-	int16_t *pRendererID; /* Win32 wchar_t* */
-	FAudio *pXAudio2;
-	FAudioMasteringVoice *pMasteringVoice;
-} FACTRuntimeParameters;
-
 typedef struct FACTStreamingParameters
 {
 	void *file;
@@ -144,6 +130,20 @@ typedef enum FACTWaveBankSegIdx
 } FACTWaveBankSegIdx;
 
 #pragma pack(push, 1)
+
+typedef struct FACTRuntimeParameters
+{
+	uint32_t lookAheadTime;
+	void *pGlobalSettingsBuffer;
+	uint32_t globalSettingsBufferSize;
+	uint32_t globalSettingsFlags;
+	uint32_t globalSettingsAllocAttributes;
+	FACTFileIOCallbacks fileIOCallbacks;
+	FACTNotificationCallback fnNotificationCallback;
+	int16_t *pRendererID; /* Win32 wchar_t* */
+	FAudio *pXAudio2;
+	FAudioMasteringVoice *pMasteringVoice;
+} FACTRuntimeParameters;
 
 typedef struct FACTWaveBankRegion
 {

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -1993,7 +1993,7 @@ uint32_t FACT_INTERNAL_ParseAudioEngine(
 	uint8_t *start = ptr;
 
 	/* FIXME: Should be recorded so we can return the correct error */
-	if (!pParams->pGlobalSettingsBuffer)
+	if (!pParams->pGlobalSettingsBuffer || pParams->globalSettingsBufferSize == 0)
 	{
 		return 0;
 	}


### PR DESCRIPTION
No sure how to handle this without breaking things.  Under 64bits the structure size is wrong.

In wine there there is code to copy the structure
memcpy (xact, fact, sizeof(fact)) which wont work when the packing is incorrect.

I can manually copy the structure in wine, which will stop one issue. 

Maybe we just mark it for an update for FAudio version 2 :)