### PR TITLE
Always set OutputFormat.SubFormat to MFAudioFormat_PCM in FAudio_PlatformGetDeviceDetails.

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -697,7 +697,8 @@ uint32_t FAudio_CreateMasteringVoice(
 	WriteWaveFormatExtensible(
 		&audio->mixFormat,
 		audio->master->outputChannels,
-		audio->master->master.inputSampleRate
+		audio->master->master.inputSampleRate,
+		&DATAFORMAT_SUBTYPE_IEEE_FLOAT
 	);
 
 	/* Platform Device */

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -768,7 +768,8 @@ static inline uint32_t GetMask(uint16_t channels)
 static inline void WriteWaveFormatExtensible(
 	FAudioWaveFormatExtensible *fmt,
 	int channels,
-	int samplerate
+	int samplerate,
+	const FAudioGUID *subformat
 ) {
 	FAudio_assert(fmt != NULL);
 	fmt->Format.wBitsPerSample = 32;
@@ -786,7 +787,7 @@ static inline void WriteWaveFormatExtensible(
 	fmt->Format.cbSize = sizeof(FAudioWaveFormatExtensible) - sizeof(FAudioWaveFormatEx);
 	fmt->Samples.wValidBitsPerSample = 32;
 	fmt->dwChannelMask = GetMask(fmt->Format.nChannels);
-	FAudio_memcpy(&fmt->SubFormat, &DATAFORMAT_SUBTYPE_IEEE_FLOAT, sizeof(FAudioGUID));
+	FAudio_memcpy(&fmt->SubFormat, subformat, sizeof(FAudioGUID));
 }
 
 /* Resampling */

--- a/src/FAudio_platform_sdl2.c
+++ b/src/FAudio_platform_sdl2.c
@@ -179,7 +179,8 @@ iosretry:
 	}
 
 	/* Write up the received format for the engine */
-	WriteWaveFormatExtensible(mixFormat, have.channels, have.freq);
+	WriteWaveFormatExtensible(mixFormat, have.channels, have.freq,
+		&DATAFORMAT_SUBTYPE_IEEE_FLOAT);
 	*updateSize = have.samples;
 
 	/* SDL_AudioDeviceID is a Uint32, anybody using a 16-bit PC still? */
@@ -260,7 +261,8 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 	{
 		channels = 2;
 	}
-	WriteWaveFormatExtensible(&details->OutputFormat, channels, rate);
+	WriteWaveFormatExtensible(&details->OutputFormat, channels, rate,
+		&DATAFORMAT_SUBTYPE_PCM);
 	return 0;
 }
 

--- a/tests/xaudio2.c
+++ b/tests/xaudio2.c
@@ -542,6 +542,22 @@ static void test_simple_streaming(IXAudio2 *xa)
     XA2CALL_V(UnregisterForCallbacks, &ecb);
 }
 
+static const GUID DATAFORMAT_SUBTYPE_PCM = {
+    0x01,
+    0x00,
+    0x10,
+    {
+        0x80,
+        0x00,
+        0x00,
+        0xAA,
+        0x00,
+        0x38,
+        0x9B,
+        0x71
+    }
+};
+
 static UINT32 test_DeviceDetails(IXAudio27 *xa)
 {
     HRESULT hr;
@@ -557,6 +573,21 @@ static UINT32 test_DeviceDetails(IXAudio27 *xa)
     for(i = 0; i < count; ++i){
         hr = IXAudio27_GetDeviceDetails(xa, i, &dd);
         ok(hr == S_OK, "GetDeviceDetails failed: %08x\n", hr);
+
+        ok(!memcmp(&dd.OutputFormat.SubFormat, &DATAFORMAT_SUBTYPE_PCM, sizeof(GUID)),
+                "Expected SubFormat of device at index %u to be MFAudioFormat_PCM. "
+                "Got {%8.8x-%4.4x-%4.4x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x}.\n", i,
+                dd.OutputFormat.SubFormat.Data1,
+                dd.OutputFormat.SubFormat.Data2,
+                dd.OutputFormat.SubFormat.Data3,
+                dd.OutputFormat.SubFormat.Data4[0],
+                dd.OutputFormat.SubFormat.Data4[1],
+                dd.OutputFormat.SubFormat.Data4[2],
+                dd.OutputFormat.SubFormat.Data4[3],
+                dd.OutputFormat.SubFormat.Data4[4],
+                dd.OutputFormat.SubFormat.Data4[5],
+                dd.OutputFormat.SubFormat.Data4[6],
+                dd.OutputFormat.SubFormat.Data4[7]);
 
         if(i == 0)
             ok(dd.Role == GlobalDefaultDevice, "Got wrong role for index 0: 0x%x\n", dd.Role);


### PR DESCRIPTION
Adds a test for the value of the OutputFormat.SubFormat UUID on the results returned from IXAudio27_GetDeviceDetails and updates FAudio_PlatformGetDeviceDetails to always set this field to MFAudioFormat_PCM, mirroring the behavior of native xaudio2.7.  This fixes in-game audio in at least two Ubisoft games (Far Cry Primal and Watch Dogs).

Fixes ValveSoftware/proton#2425