### PR TITLE
Fix compile error with tests

### DIFF
--- a/tests/xaudio2.c
+++ b/tests/xaudio2.c
@@ -542,7 +542,7 @@ static void test_simple_streaming(IXAudio2 *xa)
     XA2CALL_V(UnregisterForCallbacks, &ecb);
 }
 
-static const GUID DATAFORMAT_SUBTYPE_PCM = {
+FAudioGUID DATAFORMAT_SUBTYPE_PCM = {
     0x01,
     0x00,
     0x10,
@@ -574,7 +574,7 @@ static UINT32 test_DeviceDetails(IXAudio27 *xa)
         hr = IXAudio27_GetDeviceDetails(xa, i, &dd);
         ok(hr == S_OK, "GetDeviceDetails failed: %08x\n", hr);
 
-        ok(!memcmp(&dd.OutputFormat.SubFormat, &DATAFORMAT_SUBTYPE_PCM, sizeof(GUID)),
+        ok(!memcmp(&dd.OutputFormat.SubFormat, &DATAFORMAT_SUBTYPE_PCM, sizeof(FAudioGUID)),
                 "Expected SubFormat of device at index %u to be MFAudioFormat_PCM. "
                 "Got {%8.8x-%4.4x-%4.4x-%2.2x%2.2x-%2.2x%2.2x%2.2x%2.2x%2.2x%2.2x}.\n", i,
                 dd.OutputFormat.SubFormat.Data1,


### PR DESCRIPTION
Got some errors compiling tests with commit 03114a7 where
it seems as DATAFORMAT_SUBTYPE_PCM will be declared twice.
DATAFORMAT_SUBTYPE_PCM is already declared as "extern" in
FAudio.h for FAudioGUID.

The tests compile and run ok with this patch.

Ref to my comment here: [https://github.com/FNA-XNA/FAudio/commit/03114a7f57cf7232d4088f7dcbbff3b3f7fdbe3f#commitcomment-44268929](https://github.com/FNA-XNA/FAudio/commit/03114a7f57cf7232d4088f7dcbbff3b3f7fdbe3f#commitcomment-44268929)