### PR TITLE
Increase verbosity of SDL dependency

### DIFF
--- a/README
+++ b/README
@@ -15,7 +15,7 @@ library via FAudio#, which you can find in the 'csharp/' directory.
 
 Dependencies
 ------------
-FAudio depends solely on SDL 2.0.9+ (Ubuntu 20.04+, Debian 10+, Fedora 30+)
+FAudio depends solely on SDL 2.0.9 or newer.
 FAudio never explicitly uses the C runtime.
 
 Building FAudio

--- a/README
+++ b/README
@@ -15,7 +15,8 @@ library via FAudio#, which you can find in the 'csharp/' directory.
 
 Dependencies
 ------------
-FAudio depends solely on SDL2. FAudio never explicitly uses the C runtime.
+FAudio depends solely on SDL 2.0.9+ (Ubuntu 20.04+, Debian 10+, Fedora 30+)
+FAudio never explicitly uses the C runtime.
 
 Building FAudio
 ---------------

--- a/src/FAudio_platform_sdl2.c
+++ b/src/FAudio_platform_sdl2.c
@@ -28,6 +28,11 @@
 
 #include <SDL.h>
 
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+#else
+#error "SDL version older than 2.0.9"
+#endif /* SDL_VERSION_ATLEAST */
+
 /* Mixer Thread */
 
 static void FAudio_INTERNAL_MixCallback(void *userdata, Uint8 *stream, int len)


### PR DESCRIPTION
Restore preprocessor macro introduced in:
Commit 7b0973e62c05 ("Warning for SDL <2.0.9")
and removed in:
Commit a0f859c761bb ("Enforce a quantum size measured in millisecon...")
to reduce confusion as to the compiler errors

Include the exact version number in the README and include a few common
distributions that contain at least the requisite version

The previous version contained an #ifdef for a Windows specific
preprocessor directive but it seems to be supported now in MSVC and
other noteworthy compilers:

https://docs.microsoft.com/en-us/cpp/preprocessor/hash-error-directive-c-cpp
https://gcc.gnu.org/onlinedocs/cpp/Diagnostics.html
https://clang.llvm.org/docs/UsersManual.html#controlling-diagnostics-via-pragmas