### PR TITLE
cmake: Add Requires for gstreamer to the pkgconfig file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,9 @@ endif()
 
 # GStreamer Support
 if(GSTREAMER)
+	# Requires for gstreamer in the pkgconfig file
+	set(FAUDIO_GSTREAMER_DEPS " gstreamer-app-1.0 gstreamer-audio-1.0")
+
 	# Add the extra definition...
 	target_compile_definitions(FAudio PRIVATE HAVE_GSTREAMER=1)
 
@@ -157,6 +160,8 @@ if(GSTREAMER)
             ${GSTAUDIO_LDFLAGS}
             ${GSTAPP_LDFLAGS}
         )
+else()
+	set(FAUDIO_GSTREAMER_DEPS "")
 endif(GSTREAMER)
 
 # Dump source voices to RIFF WAVE files

--- a/cmake/FAudio.pc.in
+++ b/cmake/FAudio.pc.in
@@ -9,4 +9,5 @@ Description: Accuracy-focused XAudio reimplementation for open platforms
 Version: @LIB_VERSION@
 
 Libs: -L${libdir} -l@PROJECT_NAME@
+Requires:@FAUDIO_GSTREAMER_DEPS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Fixes https://github.com/FNA-XNA/FAudio/issues/235

With `GSTREAMER=ON`.
```
prefix=/usr/local
exec_prefix=${prefix}
libdir=${prefix}/lib64
includedir=${prefix}/include

Name: FAudio
URL: https://github.com/FNA-XNA/FAudio
Description: Accuracy-focused XAudio reimplementation for open platforms
Version: 0.21.01

Libs: -L${libdir} -lFAudio
Requires: gstreamer-app-1.0 gstreamer-audio-1.0
Cflags: -I${includedir}
```
With `GSTREAMER=OFF`.
```
prefix=/usr/local
exec_prefix=${prefix}
libdir=${prefix}/lib64
includedir=${prefix}/include

Name: FAudio
URL: https://github.com/FNA-XNA/FAudio
Description: Accuracy-focused XAudio reimplementation for open platforms
Version: 0.21.01

Libs: -L${libdir} -lFAudio
Requires:
Cflags: -I${includedir}
```
I don't have a test case, but this seems right.