### PR TITLE
process filters and effects despite empty send list

### DIFF
--- a/cpp/xaudio2.cpp
+++ b/cpp/xaudio2.cpp
@@ -376,7 +376,7 @@ static FAudioEffectChain *wrap_effect_chain(const XAUDIO2_EFFECT_CHAIN *x_chain)
 	{
 		f_chain->pEffectDescriptors[i].InitialState = x_chain->pEffectDescriptors[i].InitialState;
 		f_chain->pEffectDescriptors[i].OutputChannels =
-			x_chain->pEffectDescriptors[i].OutputChannel;
+			x_chain->pEffectDescriptors[i].OutputChannels;
 		f_chain->pEffectDescriptors[i].pEffect =
 			wrap_xapo_effect(x_chain->pEffectDescriptors[i].pEffect);
 	}

--- a/cpp/xaudio2.h
+++ b/cpp/xaudio2.h
@@ -56,7 +56,7 @@ typedef struct XAUDIO2_VOICE_SENDS {
 typedef struct XAUDIO2_EFFECT_DESCRIPTOR {
 	IUnknown *pEffect;
 	BOOL InitialState;
-	UINT32  OutputChannel;
+	UINT32  OutputChannels;
 } XAUDIO2_EFFECT_DESCRIPTOR;
 
 typedef struct XAUDIO2_EFFECT_CHAIN {

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -884,15 +884,6 @@ sendwork:
 	FAudio_PlatformLockMutex(voice->sendLock);
 	LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
 
-	/* Nowhere to send it? Just skip the rest...*/
-	if (voice->sends.SendCount == 0)
-	{
-		FAudio_PlatformUnlockMutex(voice->sendLock);
-		LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
-		LOG_FUNC_EXIT(voice->audio)
-		return;
-	}
-
 	/* Filters */
 	if (voice->flags & FAUDIO_VOICE_USEFILTER)
 	{
@@ -934,6 +925,15 @@ sendwork:
 	}
 	FAudio_PlatformUnlockMutex(voice->effectLock);
 	LOG_MUTEX_UNLOCK(voice->audio, voice->effectLock)
+
+	/* Nowhere to send it? Just skip the rest...*/
+	if (voice->sends.SendCount == 0)
+	{
+		FAudio_PlatformUnlockMutex(voice->sendLock);
+		LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+		LOG_FUNC_EXIT(voice->audio)
+		return;
+	}
 
 	/* Send float cache to sends */
 	FAudio_PlatformLockMutex(voice->volumeLock);
@@ -997,12 +997,6 @@ static void FAudio_INTERNAL_MixSubmix(FAudioSubmixVoice *voice)
 	FAudio_PlatformLockMutex(voice->sendLock);
 	LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
 
-	/* Nothing to do? */
-	if (voice->sends.SendCount == 0)
-	{
-		goto end;
-	}
-
 	/* Resample */
 	if (voice->mix.resampleStep == FIXED_ONE)
 	{
@@ -1064,6 +1058,12 @@ static void FAudio_INTERNAL_MixSubmix(FAudioSubmixVoice *voice)
 	}
 	FAudio_PlatformUnlockMutex(voice->effectLock);
 	LOG_MUTEX_UNLOCK(voice->audio, voice->effectLock)
+
+	/* Nothing more to do? */
+	if (voice->sends.SendCount == 0)
+	{
+		goto end;
+	}
 
 	/* Send float cache to sends */
 	FAudio_PlatformLockMutex(voice->volumeLock);


### PR DESCRIPTION
- Fix XAUDIO2_EFFECT_DESCRIPTOR::OutputChannels name
- Process filters and effects despite empty send list
