### PR TITLE
Fix fopen_s not being defined for stb_vorbis

### DIFF
--- a/src/XNA_Song.c
+++ b/src/XNA_Song.c
@@ -70,6 +70,7 @@
 #define SEEK_END FAUDIO_SEEK_END
 #define EOF FAUDIO_EOF
 #define fopen(path, mode) FAudio_fopen(path)
+#define fopen_s(io, path, mode) (!(*io = FAudio_fopen(path)))
 #define fclose(io) FAudio_close(io)
 #define fread(dst, size, count, io) io->read(io->data, dst, size, count)
 #define fseek(io, offset, whence) io->seek(io->data, offset, whence)


### PR DESCRIPTION
`stb_vorbis.h` can use `fopen_s` when compiled in certain environments. `XNA_Song.c` redefines `fopen`; this PR adds the missing `fopen_s` definition.