### PR TITLE
Basic FUNCTIONAL XMA2 support

### DIFF
--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -177,6 +177,36 @@ public static class FAudio
 	}
 
 	[StructLayout(LayoutKind.Sequential, Pack = 1)]
+	public struct FAudioXMA2WaveFormat
+	{
+		public FAudioWaveFormatEx wfx;
+		public ushort wNumStreams;
+		public uint dwChannelMask;
+		public uint dwSamplesEncoded;
+		public uint dwBytesPerBlock;
+		public uint dwPlayBegin;
+		public uint dwPlayLength;
+		public uint dwLoopBegin;
+		public uint dwLoopLength;
+		public byte bLoopCount;
+		public byte bEncoderVersion;
+		public ushort wBlockCount;
+	};
+
+	[StructLayout(LayoutKind.Explicit)]
+	public struct FAudioAnyWaveFormat
+	{
+		[FieldOffset(0)]
+		public FAudioWaveFormatEx wfx;
+		[FieldOffset(0)]
+		public FAudioWaveFormatExtensible wfex;
+		[FieldOffset(0)]
+		public FAudioADPCMWaveFormat wfadpcm;
+		[FieldOffset(0)]
+		public FAudioXMA2WaveFormat wfxma2;
+	}
+
+	[StructLayout(LayoutKind.Sequential, Pack = 1)]
 	public unsafe struct FAudioDeviceDetails
 	{
 		public fixed short DeviceID[256]; /* Win32 wchar_t */
@@ -406,6 +436,18 @@ public static class FAudio
 	);
 
 	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern uint FAudio_CreateSourceVoice(
+		IntPtr audio, /* FAudio* */
+		out IntPtr ppSourceVoice, /* FAudioSourceVoice** */
+		ref FAudioAnyWaveFormat pSourceFormat,
+		uint Flags,
+		float MaxFrequencyRatio,
+		IntPtr pCallback, /* FAudioVoiceCallback* */
+		IntPtr pSendList, /* FAudioVoiceSends* */
+		IntPtr pEffectChain /* FAudioEffectChain* */
+	);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 	public static extern uint FAudio_CreateSubmixVoice(
 		IntPtr audio, /* FAudio* */
 		out IntPtr ppSubmixVoice, /* FAudioSubmixVoice** */
@@ -623,6 +665,13 @@ public static class FAudio
 		IntPtr voice, /* FAudioSourceVoice* */
 		ref FAudioBuffer pBuffer,
 		IntPtr pBufferWMA /* const FAudioBufferWMA* */
+	);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern uint FAudioSourceVoice_SubmitSourceBuffer(
+		IntPtr voice, /* FAudioSourceVoice* */
+		ref FAudioBuffer pBuffer,
+		ref FAudioBufferWMA pBufferWMA
 	);
 
 	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]

--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -193,19 +193,6 @@ public static class FAudio
 		public ushort wBlockCount;
 	};
 
-	[StructLayout(LayoutKind.Explicit)]
-	public struct FAudioAnyWaveFormat
-	{
-		[FieldOffset(0)]
-		public FAudioWaveFormatEx wfx;
-		[FieldOffset(0)]
-		public FAudioWaveFormatExtensible wfex;
-		[FieldOffset(0)]
-		public FAudioADPCMWaveFormat wfadpcm;
-		[FieldOffset(0)]
-		public FAudioXMA2WaveFormat wfxma2;
-	}
-
 	[StructLayout(LayoutKind.Sequential, Pack = 1)]
 	public unsafe struct FAudioDeviceDetails
 	{
@@ -439,7 +426,7 @@ public static class FAudio
 	public static extern uint FAudio_CreateSourceVoice(
 		IntPtr audio, /* FAudio* */
 		out IntPtr ppSourceVoice, /* FAudioSourceVoice** */
-		ref FAudioAnyWaveFormat pSourceFormat,
+		IntPtr pSourceFormat, /* FAudioWaveFormatEx* */
 		uint Flags,
 		float MaxFrequencyRatio,
 		IntPtr pCallback, /* FAudioVoiceCallback* */

--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -176,8 +176,7 @@ public static class FAudio
 		 */
 	}
 
-	[StructLayout(LayoutKind.Sequential, Pack = 1)]
-	public struct FAudioXMA2WaveFormat
+	public struct FAudioXMA2WaveFormatEx
 	{
 		public FAudioWaveFormatEx wfx;
 		public ushort wNumStreams;

--- a/include/FAudio.h
+++ b/include/FAudio.h
@@ -186,9 +186,6 @@ typedef struct FAudioADPCMWaveFormat
 	#endif
 } FAudioADPCMWaveFormat;
 
-/* See DirectXTK, MIT-licensed:
- * https://github.com/microsoft/DirectXTK/blob/6b395cc7f4203ddae40314433f79c6da92fa7f08/XWBTool/xwbtool.cpp#L67
- */
 typedef struct FAudioXMA2WaveFormat
 {
 	FAudioWaveFormatEx wfx;
@@ -204,15 +201,6 @@ typedef struct FAudioXMA2WaveFormat
 	uint8_t  bEncoderVersion;
 	uint16_t wBlockCount;
 } FAudioXMA2WaveFormat;
-
-typedef union FAudioAnyWaveFormat
-{
-	FAudioWaveFormatEx;
-	FAudioWaveFormatEx wfx;
-	FAudioWaveFormatExtensible wfex;
-	FAudioADPCMWaveFormat wfadpcm;
-	FAudioXMA2WaveFormat wfxma2;
-} FAudioAnyWaveFormat;
 
 typedef struct FAudioDeviceDetails
 {
@@ -617,7 +605,7 @@ FAUDIOAPI void FAudio_UnregisterForCallbacks(
 FAUDIOAPI uint32_t FAudio_CreateSourceVoice(
 	FAudio *audio,
 	FAudioSourceVoice **ppSourceVoice,
-	const FAudioAnyWaveFormat *pSourceFormat,
+	const FAudioWaveFormatEx *pSourceFormat,
 	uint32_t Flags,
 	float MaxFrequencyRatio,
 	FAudioVoiceCallback *pCallback,

--- a/include/FAudio.h
+++ b/include/FAudio.h
@@ -186,6 +186,34 @@ typedef struct FAudioADPCMWaveFormat
 	#endif
 } FAudioADPCMWaveFormat;
 
+/* See DirectXTK, MIT-licensed:
+ * https://github.com/microsoft/DirectXTK/blob/6b395cc7f4203ddae40314433f79c6da92fa7f08/XWBTool/xwbtool.cpp#L67
+ */
+typedef struct FAudioXMA2WaveFormat
+{
+	FAudioWaveFormatEx wfx;
+	uint16_t wNumStreams;
+	uint32_t dwChannelMask;
+	uint32_t dwSamplesEncoded;
+	uint32_t dwBytesPerBlock;
+	uint32_t dwPlayBegin;
+	uint32_t dwPlayLength;
+	uint32_t dwLoopBegin;
+	uint32_t dwLoopLength;
+	uint8_t  bLoopCount;
+	uint8_t  bEncoderVersion;
+	uint16_t wBlockCount;
+} FAudioXMA2WaveFormat;
+
+typedef union FAudioAnyWaveFormat
+{
+	FAudioWaveFormatEx;
+	FAudioWaveFormatEx wfx;
+	FAudioWaveFormatExtensible wfex;
+	FAudioADPCMWaveFormat wfadpcm;
+	FAudioXMA2WaveFormat wfxma2;
+} FAudioAnyWaveFormat;
+
 typedef struct FAudioDeviceDetails
 {
 	int16_t DeviceID[256]; /* Win32 wchar_t */
@@ -589,7 +617,7 @@ FAUDIOAPI void FAudio_UnregisterForCallbacks(
 FAUDIOAPI uint32_t FAudio_CreateSourceVoice(
 	FAudio *audio,
 	FAudioSourceVoice **ppSourceVoice,
-	const FAudioWaveFormatEx *pSourceFormat,
+	const FAudioAnyWaveFormat *pSourceFormat,
 	uint32_t Flags,
 	float MaxFrequencyRatio,
 	FAudioVoiceCallback *pCallback,

--- a/include/FAudio.h
+++ b/include/FAudio.h
@@ -186,22 +186,6 @@ typedef struct FAudioADPCMWaveFormat
 	#endif
 } FAudioADPCMWaveFormat;
 
-typedef struct FAudioXMA2WaveFormat
-{
-	FAudioWaveFormatEx wfx;
-	uint16_t wNumStreams;
-	uint32_t dwChannelMask;
-	uint32_t dwSamplesEncoded;
-	uint32_t dwBytesPerBlock;
-	uint32_t dwPlayBegin;
-	uint32_t dwPlayLength;
-	uint32_t dwLoopBegin;
-	uint32_t dwLoopLength;
-	uint8_t  bLoopCount;
-	uint8_t  bEncoderVersion;
-	uint16_t wBlockCount;
-} FAudioXMA2WaveFormat;
-
 typedef struct FAudioDeviceDetails
 {
 	int16_t DeviceID[256]; /* Win32 wchar_t */
@@ -327,6 +311,25 @@ typedef struct FAudioDebugConfiguration
 } FAudioDebugConfiguration;
 
 #pragma pack(pop)
+
+/* This ISN'T packed. Strictly speaking it wouldn't have mattered anyway but eh.
+ * See https://github.com/microsoft/DirectXTK/issues/256
+ */
+typedef struct FAudioXMA2WaveFormatEx
+{
+	FAudioWaveFormatEx wfx;
+	uint16_t wNumStreams;
+	uint32_t dwChannelMask;
+	uint32_t dwSamplesEncoded;
+	uint32_t dwBytesPerBlock;
+	uint32_t dwPlayBegin;
+	uint32_t dwPlayLength;
+	uint32_t dwLoopBegin;
+	uint32_t dwLoopLength;
+	uint8_t  bLoopCount;
+	uint8_t  bEncoderVersion;
+	uint16_t wBlockCount;
+} FAudioXMA2WaveFormat;
 
 /* Constants */
 

--- a/src/FACT.c
+++ b/src/FACT.c
@@ -1741,9 +1741,6 @@ uint32_t FACTWaveBank_Prepare(
 		 *
 		 * dwSamplesEncoded is usually close to dwPlayLength but not always (if ever?) equal. Let's assume equality.
 		 * The XMA2 seek table uses sample indices as opposed to WMA's byte index seek table.
-		 * The last entry matches the length accurately enough and we can just use that.
-		 * BUT everything else expects the seek table to be byte index based!
-		 * CTRL+F "XMA2 seek tables" in FACT_internal.c for more information.
 		 *
 		 * nBlockAlign uses aWMABlockAlign given the entire WMA Pro thing BUT it's expected to be the block size for decoding.
 		 * The XMA2 block size MUST be a multiple of 2048 BUT entry->PlayRegion.dwLength / seek->entryCount doesn't respect that.
@@ -1768,7 +1765,7 @@ uint32_t FACTWaveBank_Prepare(
 		);
 		format.xma2.wNumStreams = (format.pcm.nChannels + 1) / 2;
 		format.xma2.dwChannelMask = format.pcm.nChannels > 1 ? 0xFFFFFFFF >> (32 - format.pcm.nChannels) : 0;
-		format.xma2.dwSamplesEncoded = seek->entries[seek->entryCount - 1] / format.pcm.nChannels / format.pcm.wBitsPerSample / 8;
+		format.xma2.dwSamplesEncoded = seek->entries[seek->entryCount - 1];
 		format.xma2.dwBytesPerBlock = (uint16_t) FAudio_ceil(
 			(double) entry->PlayRegion.dwLength /
 			(double) seek->entryCount /
@@ -1889,8 +1886,7 @@ uint32_t FACTWaveBank_Prepare(
 			buffer.LoopCount = nLoopCount;
 		}
 		buffer.pContext = NULL;
-		if (	format.pcm.wFormatTag == FAUDIO_FORMAT_WMAUDIO2 ||
-			format.pcm.wFormatTag == FAUDIO_FORMAT_XMAUDIO2	)
+		if (format.pcm.wFormatTag == FAUDIO_FORMAT_WMAUDIO2)
 		{
 			bufferWMA.pDecodedPacketCumulativeBytes =
 				pWaveBank->seekTables[nWaveIndex].entries;

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -3275,6 +3275,24 @@ uint32_t FACT_INTERNAL_ParseWaveBank(
 					DOSWAP_32(wb->seekTables[i].entries[j]);
 				}
 			}
+
+			/* XMA2 seek tables use sample indices, not byte indices.
+			 * Pretty much everything under the sun expects byte indices.
+			 * Let's convert the seek table. WHAT CAN GO WRONG?
+			 * CTRL+F "XMA2 seek tables" in FACT.c if one must change this.
+			 * -ade
+			 */
+			if (wb->entries[i].Format.wFormatTag == 0x1)
+			{
+				for (j = 0; j < wb->seekTables[i].entryCount; j += 1)
+				{
+					wb->seekTables[i].entries[j] = (
+						wb->seekTables[i].entries[j] *
+						wb->entries[i].Format.nChannels *
+						((8 << wb->entries[i].Format.wBitsPerSample) / 8)
+					);
+				}
+			}
 		}
 	}
 	else

--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -1888,8 +1888,7 @@ void FACT_INTERNAL_OnBufferEnd(FAudioVoiceCallback *callback, void* pContext)
 	buffer.pContext = NULL;
 
 	/* Submit, finally. */
-	if (	entry->Format.wFormatTag == 0x1 ||
-		entry->Format.wFormatTag == 0x3	)
+	if (entry->Format.wFormatTag == 0x1)
 	{
 		bufferWMA.pDecodedPacketCumulativeBytes =
 			c->wave->parentBank->seekTables[c->wave->index].entries;
@@ -3273,24 +3272,6 @@ uint32_t FACT_INTERNAL_ParseWaveBank(
 				for (j = 0; j < wb->seekTables[i].entryCount; j += 1)
 				{
 					DOSWAP_32(wb->seekTables[i].entries[j]);
-				}
-			}
-
-			/* XMA2 seek tables use sample indices, not byte indices.
-			 * Pretty much everything under the sun expects byte indices.
-			 * Let's convert the seek table. WHAT CAN GO WRONG?
-			 * CTRL+F "XMA2 seek tables" in FACT.c if one must change this.
-			 * -ade
-			 */
-			if (wb->entries[i].Format.wFormatTag == 0x1)
-			{
-				for (j = 0; j < wb->seekTables[i].entryCount; j += 1)
-				{
-					wb->seekTables[i].entries[j] = (
-						wb->seekTables[i].entries[j] *
-						wb->entries[i].Format.nChannels *
-						((8 << wb->entries[i].Format.wBitsPerSample) / 8)
-					);
 				}
 			}
 		}

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -2453,8 +2453,8 @@ uint32_t FAudioSourceVoice_SubmitSourceBuffer(
 
 	FAudio_assert(voice->type == FAUDIO_VOICE_SOURCE);
 #ifdef HAVE_GSTREAMER
-	FAudio_assert(	(voice->src.gstreamer != NULL && pBufferWMA != NULL) ||
-			(voice->src.gstreamer == NULL && pBufferWMA == NULL)	);
+	FAudio_assert(	(voice->src.gstreamer != NULL && (pBufferWMA != NULL || voice->src.format->wFormatTag == FAUDIO_FORMAT_XMAUDIO2)) ||
+			(voice->src.gstreamer == NULL && (pBufferWMA == NULL && voice->src.format->wFormatTag != FAUDIO_FORMAT_XMAUDIO2))	);
 #endif /* HAVE_GSTREAMER */
 
 	/* Start off with whatever they just sent us... */
@@ -2503,7 +2503,7 @@ uint32_t FAudioSourceVoice_SubmitSourceBuffer(
 		}
 	}
 
-	if (pBuffer->LoopCount > 0 && pBufferWMA == NULL)
+	if (pBuffer->LoopCount > 0 && pBufferWMA == NULL && voice->src.format->wFormatTag != FAUDIO_FORMAT_XMAUDIO2)
 	{
 		/* "The value of LoopBegin must be less than PlayBegin + PlayLength" */
 		if (loopBegin >= (playBegin + playLength))
@@ -2545,7 +2545,7 @@ uint32_t FAudioSourceVoice_SubmitSourceBuffer(
 			pBuffer->AudioBytes / voice->src.format->nBlockAlign
 		) * voice->src.format->nBlockAlign;
 	}
-	else if (pBufferWMA != NULL)
+	else if (pBufferWMA != NULL || voice->src.format->wFormatTag == FAUDIO_FORMAT_XMAUDIO2)
 	{
 		/* WMA only supports looping the whole buffer */
 		loopBegin = 0;

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -46,7 +46,6 @@
 MAKE_SUBFORMAT_GUID(PCM, 1);
 MAKE_SUBFORMAT_GUID(ADPCM, 2);
 MAKE_SUBFORMAT_GUID(IEEE_FLOAT, 3);
-/* FIXME: Is this still necessary? XMAUDIO2 is now separate from Extensible as it holds extra data. */
 MAKE_SUBFORMAT_GUID(XMAUDIO2, FAUDIO_FORMAT_XMAUDIO2);
 MAKE_SUBFORMAT_GUID(WMAUDIO2, FAUDIO_FORMAT_WMAUDIO2);
 MAKE_SUBFORMAT_GUID(WMAUDIO3, FAUDIO_FORMAT_WMAUDIO3);
@@ -259,7 +258,7 @@ void FAudio_UnregisterForCallbacks(
 uint32_t FAudio_CreateSourceVoice(
 	FAudio *audio,
 	FAudioSourceVoice **ppSourceVoice,
-	const FAudioAnyWaveFormat *pSourceFormat,
+	const FAudioWaveFormatEx *pSourceFormat,
 	uint32_t Flags,
 	float MaxFrequencyRatio,
 	FAudioVoiceCallback *pCallback,

--- a/src/FAudio_gstreamer.c
+++ b/src/FAudio_gstreamer.c
@@ -262,7 +262,7 @@ static int FAudio_GSTREAMER_DecodeBlock(FAudioVoice *voice, FAudioBuffer *buffer
 	uint8_t *tmpBuf;
 	size_t tmpLen;
 
-	if (gstreamer->curBlock != ~0u && block != gstreamer->curBlock && block != gstreamer->curBlock + 1)
+	if (gstreamer->curBlock != ~0u && block != gstreamer->curBlock + 1)
 	{
 		/* XAudio2 allows looping back to start of XMA buffers, but nothing else */
 		if (block != 0)
@@ -435,9 +435,7 @@ done:
 	/* If the cache isn't filled yet, keep decoding! */
 	if (samples > 0)
 	{
-		if (	!error &&
-			curBlock < blockCount - 1 &&
-			availableBytes != 0	)
+		if (!error && curBlock < blockCount - 1)
 		{
 			goto decode;
 		}

--- a/src/FAudio_gstreamer.c
+++ b/src/FAudio_gstreamer.c
@@ -727,8 +727,8 @@ uint32_t FAudio_GSTREAMER_init(FAudioSourceVoice *pSourceVoice, uint32_t type)
 	if (type == FAUDIO_FORMAT_WMAUDIO3)
 	{
 		const FAudioWaveFormatExtensible *wfx =
-			(FAudioWaveFormatExtensible*)pSourceVoice->src.format;
-		extradata = (uint8_t*)&wfx->Samples;
+			(FAudioWaveFormatExtensible*) pSourceVoice->src.format;
+		extradata = (uint8_t*) &wfx->Samples;
 		codec_data_size = pSourceVoice->src.format->cbSize;
 		result->blockCount = pSourceVoice->src.bufferList->bufferWMA.PacketCount;
 		result->maxBytes = pSourceVoice->src.bufferList->bufferWMA.pDecodedPacketCumulativeBytes[result->blockCount - 1];

--- a/src/FAudio_gstreamer.c
+++ b/src/FAudio_gstreamer.c
@@ -586,9 +586,9 @@ uint32_t FAudio_GSTREAMER_init(FAudioSourceVoice *pSourceVoice, uint32_t type)
 	GSTTYPE(WMAUDIO3, "audio/x-wma", "wmaversion", 3)
 	GSTTYPE(WMAUDIO_LOSSLESS, "audio/x-wma", "wmaversion", 4)
 #ifndef FAUDIO_GST_LIBAV_EXPOSES_XMA2_CAPS_IN_CURRENT_YEAR
-		GSTTYPE(XMAUDIO2, FAudio_GSTREAMER_XMA2_Mimetype, "xmaversion", 2)
+	GSTTYPE(XMAUDIO2, FAudio_GSTREAMER_XMA2_Mimetype, "xmaversion", 2)
 #else
-		GSTTYPE(XMAUDIO2, "audio/x-xma", "xmaversion", 2)
+	GSTTYPE(XMAUDIO2, "audio/x-xma", "xmaversion", 2)
 #endif
 	#undef GSTTYPE
 	default:


### PR DESCRIPTION
Compared to #66, this is no longer "initial" and it's no longer taking stupid shortcuts.

_\*breathes in\*_

- `gst-libav` ships with `avdec_xma2` (citation needed). While we could [wait for every distro under the sun to expose proper sink caps,](https://gitlab.freedesktop.org/gstreamer/gst-libav/-/merge_requests/124) I've taken the creative liberty to add an optional `autoplug-factories` handler with some dynamic mimetype shenanigans for that specific factory.
- I've added `FAudioXMA2WaveFormat` as FFmpeg currently accepts (but doesn't fully respect) XMA2 extra data.
    - XMA2 wave data no longer gets packed into `FAudioWaveFormatExtensible`. Goodbye, broken shortcuts!
    - To handle the multitude of wave formats more easily, I've added `FAudioAnyWaveFormat` as an union of all wave formats.
- The C# bindings for `FAudio_CreateSourceVoice` and `FAudioSourceVoice_SubmitSourceBuffer` have been modified to take multiple wave formats and `FAudioBufferWMA` into account. Given how both are passed by reference and not by value anyway, I'm expecting things to end up fine. Please let me know if I'm overlooking something though, no matter how obvious.
- `FACTWaveBank_Prepare` reconstructs as much of the XMA2 extra data as necessary and documents all the quirks I've encountered for future reference. Maybe a future replacement decoder will verify the accuracy of this.
- The XMA2 seek table uses **sample indices**, unlike the WMA decoded packet cumulative **bytes** table. FACT converts the seek table to the byte index format that everything else expects.
- `nBlockAlign` wasn't enough to feed the decoder with properly sized blocks (in part due to its 16-bit size limitation) - the GStreamer decoder now uses `dwBytesPerBlock` (32-bit) when necessary.
    - ... and who knows if XMA2 _really_ "is quite similar to WMA Pro" in that aspect...
- The XMA2 data end can be misaligned to the block size while still being aligned to the packet size (2kB). FFmpeg standalone doesn't care about this (it always uses the 2kB packet size), but we must handle this properly.
    - Speaking of misaligned ends: `FAudio_GSTREAMER_FillConvertCache` happily read beyond the amount of encoded bytes into unknown territory. This PR changes that to feed undersized end buffers properly, but I don't know if every format expects that. Checking for the format type and handling it accordingly (return early? pad?) is out of the scope of this PR though.
- I've encountered a deadlock or two with the GStreamer decoder along the way, mainly "we need more samples, let's retry infinitely no matter if we're re-decoding the same block or if we're clearly out of data." As with the C# bindings, please let me know of any side effects which I'm not aware of.
- `FACTWaveBank_GetWaveProperties` now asserts when encountering XMA2 because I've yet to encounter a game that calls it and who knows what games expect? If required, I'll follow up with an approximate implementation.
- prolly some other things ive forgotten abt idk

_\*breathes out\*_

Some things are handled outside of this PR, namely a [FACT big endian variation table fix](https://github.com/FNA-XNA/FAudio/commit/e18b700fe2240d37be815de3a9dc3106596df87c) (thanks for merging that ahead of time!) and a FNA PR which I'll follow up with soon.

By the way, **this finally fixes all XMA2 bugs related to #95 which I've encountered.**