### PR TITLE
Fix WMA BufferWMA bug introduced with XMA2 patchset

### DIFF
--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -1888,7 +1888,7 @@ void FACT_INTERNAL_OnBufferEnd(FAudioVoiceCallback *callback, void* pContext)
 	buffer.pContext = NULL;
 
 	/* Submit, finally. */
-	if (entry->Format.wFormatTag == 0x1)
+	if (entry->Format.wFormatTag == 0x3)
 	{
 		bufferWMA.pDecodedPacketCumulativeBytes =
 			c->wave->parentBank->seekTables[c->wave->index].entries;


### PR DESCRIPTION
This PR fixes an oversight from #247: https://github.com/FNA-XNA/FAudio/pull/247/files#diff-5e9d130bd3d0e6c75ac5c66ff39127498b853b107dbf8d5e1882ba3478e64ef9L1891-R1891

I've mistakenly removed `0x3` (xWMA) from the check when `0x1` (XMA2) was supposed to be removed.