### PR TITLE
Loop region length can be 0

### DIFF
--- a/src/FACT.c
+++ b/src/FACT.c
@@ -1851,7 +1851,7 @@ uint32_t FACTWaveBank_Prepare(
 
 			/* XACT does NOT support loop subregions for these formats */
 			FAudio_assert(entry->LoopRegion.dwStartSample == 0);
-			FAudio_assert(entry->LoopRegion.dwTotalSamples == entry->Duration);
+			FAudio_assert(entry->LoopRegion.dwTotalSamples == 0 || entry->LoopRegion.dwTotalSamples == entry->Duration);
 		}
 		(*ppWave)->streamCache = (uint8_t*) pWaveBank->parentEngine->pMalloc(
 			(*ppWave)->streamSize


### PR DESCRIPTION
I've encountered a game with looping sounds yet loop regions with a length of zero. Apparently this is valid...