### PR TITLE
Add support for client-provided platform callbacks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(FAudio C)
 
 # Options
 option(GSTREAMER "Enable GStreamer support (WMA, XMA)" OFF)
+option(PLATFORM_CALLBACKS "Enable Platform callbacks instead of SDL2" OFF)
 option(BUILD_UTILS "Build utils/ folder" OFF)
 option(BUILD_TESTS "Build tests/ folder for unit tests to be executed on the host against FAudio" OFF)
 if(WIN32)
@@ -98,10 +99,18 @@ add_library(FAudio
 	src/FAudio_internal_simd.c
 	src/FAudio_operationset.c
 	src/FAudio_platform_sdl2.c
+	src/FAudio_platform_custom.c
 	# Optional source files
 	src/XNA_Song.c
 	src/FAudio_gstreamer.c
 )
+
+if(PLATFORM_CALLBACKS)
+	target_compile_definitions(FAudio PUBLIC FAUDIO_PLATFORM_CALLBACKS)
+	set(PLATFORM_CALLBACKS_CFLAGS "-DFAUDIO_PLATFORM_CALLBACKS")
+else()
+	set(PLATFORM_CALLBACKS_CFLAGS)
+endif()
 
 # Only disable DebugConfiguration in release builds
 if(NOT FORCE_ENABLE_DEBUGCONFIGURATION)
@@ -170,7 +179,9 @@ if(DUMP_VOICES)
 endif()
 
 # SDL2 Dependency
-if (DEFINED SDL2_INCLUDE_DIRS AND DEFINED SDL2_LIBRARIES)
+if (PLATFORM_CALLBACKS)
+	message(STATUS "not using SDL2")
+elseif (DEFINED SDL2_INCLUDE_DIRS AND DEFINED SDL2_LIBRARIES)
 	message(STATUS "using pre-defined SDL2 variables SDL2_INCLUDE_DIRS and SDL2_LIBRARIES")
 	target_include_directories(FAudio PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
 	target_link_libraries(FAudio PUBLIC ${SDL2_LIBRARIES})

--- a/cmake/FAudio.pc.in
+++ b/cmake/FAudio.pc.in
@@ -10,4 +10,4 @@ Version: @LIB_VERSION@
 
 Libs: -L${libdir} -l@PROJECT_NAME@
 Requires:@FAUDIO_GSTREAMER_DEPS@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @PLATFORM_CALLBACKS_CFLAGS@

--- a/include/FAudio.h
+++ b/include/FAudio.h
@@ -1313,6 +1313,65 @@ FAUDIOAPI FAudioIOStream* FAudio_memopen(void *mem, int len);
 FAUDIOAPI uint8_t* FAudio_memptr(FAudioIOStream *io, size_t offset);
 FAUDIOAPI void FAudio_close(FAudioIOStream *io);
 
+/* FAudio Platform API */
+
+/* Threading Types */
+
+typedef void* FAudioThread;
+typedef void* FAudioMutex;
+typedef int32_t (FAUDIOCALL * FAudioThreadFunc)(void* data);
+typedef enum FAudioThreadPriority
+{
+	FAUDIO_THREAD_PRIORITY_LOW,
+	FAUDIO_THREAD_PRIORITY_NORMAL,
+	FAUDIO_THREAD_PRIORITY_HIGH,
+} FAudioThreadPriority;
+
+typedef void (FAUDIOCALL *FAudioPlatformCallback)(void *, char *stream, int len);
+
+typedef struct FAudioPlatform
+{
+	int (FAUDIOCALL *pHasSSE2)(void);
+	int (FAUDIOCALL *pHasNEON)(void);
+
+	void (FAUDIOCALL *pPlatformAddRef)(void);
+	void (FAUDIOCALL *pPlatformRelease)(void);
+	void (FAUDIOCALL *pPlatformInit)(
+		FAudio *audio,
+		uint32_t flags,
+		uint32_t deviceIndex,
+		FAudioWaveFormatExtensible *mixFormat,
+		uint32_t *updateSize,
+		FAudioPlatformCallback callback,
+		void** platformDevice
+	);
+	void (FAUDIOCALL *pPlatformQuit)(void *platformDevice);
+	void (FAUDIOCALL *psleep)(uint32_t ms);
+	uint32_t (FAUDIOCALL *ptimems)(void);
+
+	FAudioMutex (FAUDIOCALL *pCreateMutex)(void);
+	void (FAUDIOCALL *pLockMutex)(FAudioMutex mutex);
+	void (FAUDIOCALL *pUnlockMutex)(FAudioMutex mutex);
+	void (FAUDIOCALL *pDestroyMutex)(FAudioMutex mutex);
+
+	FAudioThread (FAUDIOCALL *pCreateThread)(
+		FAudioThreadFunc func,
+		const char *name,
+		void* data
+	);
+	uint64_t (FAUDIOCALL *pGetThreadID)(void);
+	void (FAUDIOCALL *pThreadPriority)(FAudioThreadPriority priority);
+	void (FAUDIOCALL *pWaitThread)(FAudioThread thread, int32_t *retval);
+
+	uint32_t (FAUDIOCALL *pGetDeviceCount)(void);
+	uint32_t (FAUDIOCALL *pGetDeviceDetails)(
+		uint32_t index,
+		FAudioDeviceDetails *details
+	);
+} FAudioPlatform;
+
+FAUDIOAPI void FAudio_SetPlatform(const FAudioPlatform *platform);
+
 #ifdef __cplusplus
 }
 #endif /* __cplusplus */

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -28,19 +28,20 @@
 #include "FAPOBase.h"
 #include <stdarg.h>
 
-#ifdef FAUDIO_UNKNOWN_PLATFORM
+#ifdef FAUDIO_PLATFORM_CALLBACKS
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
 #include <assert.h>
 #include <inttypes.h>
+#include <alloca.h>
 
 #define FAudio_malloc malloc
 #define FAudio_realloc realloc
 #define FAudio_free free
-#define FAudio_alloca(x) alloca(uint8_t, x)
-#define FAudio_dealloca(x) dealloca(x)
+#define FAudio_alloca(x) alloca(x)
+#define FAudio_dealloca(x) (void)(x)
 #define FAudio_zero(ptr, size) memset(ptr, '\0', size)
 #define FAudio_memset(ptr, val, size) memset(ptr, val, size)
 #define FAudio_memcpy(dst, src, size) memcpy(dst, src, size)
@@ -49,7 +50,7 @@
 
 #define FAudio_strlen(ptr) strlen(ptr)
 #define FAudio_strcmp(str1, str2) strcmp(str1, str2)
-#define FAudio_strlcpy(ptr1, ptr2, size) strlcpy(ptr1, ptr2, size)
+#define FAudio_strlcpy(ptr1, ptr2, size) do { strncpy(ptr1, ptr2, size); ptr1[size - 1] = 0; } while(0)
 
 #define FAudio_pow(x, y) pow(x, y)
 #define FAudio_log(x) log(x)
@@ -202,18 +203,6 @@
 #if defined(__cplusplus) && !defined(restrict)
 #define restrict
 #endif
-
-/* Threading Types */
-
-typedef void* FAudioThread;
-typedef void* FAudioMutex;
-typedef int32_t (FAUDIOCALL * FAudioThreadFunc)(void* data);
-typedef enum FAudioThreadPriority
-{
-	FAUDIO_THREAD_PRIORITY_LOW,
-	FAUDIO_THREAD_PRIORITY_NORMAL,
-	FAUDIO_THREAD_PRIORITY_HIGH,
-} FAudioThreadPriority;
 
 /* Linked Lists */
 

--- a/src/FAudio_platform_custom.c
+++ b/src/FAudio_platform_custom.c
@@ -1,0 +1,265 @@
+/* FAudio - XAudio Reimplementation for FNA
+ *
+ * Copyright (c) 2011-2020 Ethan Lee, Luigi Auriemma, and the MonoGame Team
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Ethan "flibitijibibo" Lee <flibitijibibo@flibitijibibo.com>
+ *
+ */
+
+#include "FAudio_internal.h"
+
+#ifdef FAUDIO_PLATFORM_CALLBACKS
+
+static const FAudioPlatform *platform;
+
+FAUDIOAPI void FAudio_SetPlatform(const FAudioPlatform *callbacks)
+{
+        platform = callbacks;
+}
+
+static void FAUDIOCALL FAudio_INTERNAL_MixCallback(void *userdata, char *stream, int len)
+{
+        FAudio *audio = (FAudio*) userdata;
+
+        FAudio_zero(stream, len);
+        if (audio->active)
+        {
+                FAudio_INTERNAL_UpdateEngine(
+                        audio,
+                        (float*) stream
+                );
+        }
+}
+
+void FAudio_PlatformInit(
+        FAudio *audio,
+        uint32_t flags,
+        uint32_t deviceIndex,
+        FAudioWaveFormatExtensible *mixFormat,
+        uint32_t *updateSize,
+        void** platformDevice
+)
+{
+        FAudio_INTERNAL_InitSIMDFunctions(
+                platform->pHasSSE2(),
+                platform->pHasNEON()
+        );
+        platform->pPlatformInit(audio, flags, deviceIndex,
+                                mixFormat, updateSize,
+                                FAudio_INTERNAL_MixCallback,
+                                platformDevice);
+}
+
+void FAudio_PlatformQuit(void* platformDevice)
+{
+        platform->pPlatformQuit(platformDevice);
+}
+
+void FAudio_PlatformAddRef()
+{
+        platform->pPlatformAddRef();
+}
+
+void FAudio_PlatformRelease()
+{
+        platform->pPlatformRelease();
+}
+
+uint32_t FAudio_PlatformGetDeviceCount(void)
+{
+        return platform->pGetDeviceCount();
+}
+
+uint32_t FAudio_PlatformGetDeviceDetails(
+        uint32_t index,
+        FAudioDeviceDetails *details
+)
+{
+        return platform->pGetDeviceDetails(index, details);
+}
+
+FAudioMutex FAudio_PlatformCreateMutex(void)
+{
+        return platform->pCreateMutex();
+}
+
+void FAudio_PlatformLockMutex(FAudioMutex mutex)
+{
+        return platform->pLockMutex(mutex);
+}
+
+void FAudio_PlatformUnlockMutex(FAudioMutex mutex)
+{
+        return platform->pUnlockMutex(mutex);
+}
+
+void FAudio_PlatformDestroyMutex(FAudioMutex mutex)
+{
+        return platform->pDestroyMutex(mutex);
+}
+
+FAudioThread FAudio_PlatformCreateThread(
+        FAudioThreadFunc func,
+        const char *name,
+        void* data
+)
+{
+        return platform->pCreateThread(func, name, data);
+}
+
+void FAudio_PlatformWaitThread(FAudioThread thread, int32_t *retval)
+{
+        platform->pWaitThread(thread, retval);
+}
+
+void FAudio_PlatformThreadPriority(FAudioThreadPriority priority)
+{
+        platform->pThreadPriority(priority);
+}
+
+uint64_t FAudio_PlatformGetThreadID(void)
+{
+        return platform->pGetThreadID();
+}
+
+void FAudio_sleep(uint32_t ms)
+{
+        platform->psleep(ms);
+}
+
+uint32_t FAudio_timems()
+{
+        platform->ptimems();
+}
+
+/* FAudio I/O */
+
+static size_t FAUDIOCALL FAudio_FILE_read(void *data, void *dst, size_t size, size_t count)
+{
+        if (!data) return 0;
+        return fread(dst, size, count, data);
+}
+
+static int64_t FAUDIOCALL FAudio_FILE_seek(void *data, int64_t offset, int whence)
+{
+        if (!data) return -1;
+        fseek(data, offset, whence);
+        return ftell(data);
+}
+
+static int FAUDIOCALL FAudio_FILE_close(void *data)
+{
+        if (!data) return 0;
+        fclose(data);
+        return 0;
+}
+
+FAudioIOStream* FAudio_fopen(const char *path)
+{
+        FAudioIOStream *io = (FAudioIOStream*) FAudio_malloc(
+                sizeof(FAudioIOStream)
+        );
+        io->data = fopen(path, "rb");
+        io->read = FAudio_FILE_read;
+        io->seek = FAudio_FILE_seek;
+        io->close = FAudio_FILE_close;
+        io->lock = FAudio_PlatformCreateMutex();
+        return io;
+}
+
+struct FAudio_mem
+{
+        char *mem;
+        int64_t len;
+        int64_t pos;
+};
+
+static size_t FAUDIOCALL FAudio_mem_read(void *data, void *dst, size_t size, size_t count)
+{
+        struct FAudio_mem *io = data;
+        size_t len = size * count;
+        if (!data) return 0;
+        while (len && len > (io->len - io->pos)) len -= size;
+        memcpy(dst, io->mem + io->pos, len);
+        io->pos += len;
+        return len;
+}
+
+static int64_t FAUDIOCALL FAudio_mem_seek(void *data, int64_t offset, int whence)
+{
+        struct FAudio_mem *io = data;
+        if (!data) return -1;
+        if (whence == SEEK_SET)
+        {
+                if (io->len > offset) io->pos = offset;
+                else io->pos = io->len;
+        }
+        if (whence == SEEK_CUR)
+        {
+                if (io->len > io->pos + offset) io->pos += offset;
+                else io->pos = io->len;
+        }
+        if (whence == SEEK_END)
+        {
+                if (io->len > offset) io->pos = io->len - offset;
+                else io->pos = 0;
+        }
+        return io->pos;
+}
+
+static int FAUDIOCALL FAudio_mem_close(void *data)
+{
+        if (!data) return 0;
+        FAudio_free(data);
+}
+
+FAudioIOStream* FAudio_memopen(void *mem, int len)
+{
+        FAudioIOStream *io = (FAudioIOStream*) FAudio_malloc(
+                sizeof(FAudioIOStream)
+        );
+        struct FAudio_mem *data = FAudio_malloc(sizeof(struct FAudio_mem));
+        data->mem = mem;
+        data->len = len;
+        data->pos = 0;
+
+        io->data = data;
+        io->read = FAudio_mem_read;
+        io->seek = FAudio_mem_seek;
+        io->close = FAudio_mem_close;
+        io->lock = FAudio_PlatformCreateMutex();
+        return io;
+}
+
+uint8_t* FAudio_memptr(FAudioIOStream *io, size_t offset)
+{
+        struct FAudio_mem *memio = io->data;
+        return memio->mem + offset;
+}
+
+void FAudio_close(FAudioIOStream *io)
+{
+        io->close(io->data);
+        FAudio_PlatformDestroyMutex((FAudioMutex) io->lock);
+        FAudio_free(io);
+}
+
+#endif

--- a/src/FAudio_platform_sdl2.c
+++ b/src/FAudio_platform_sdl2.c
@@ -26,6 +26,7 @@
 
 #include "FAudio_internal.h"
 
+#ifndef FAUDIO_PLATFORM_CALLBACKS
 #include <SDL.h>
 
 #if !SDL_VERSION_ATLEAST(2, 0, 9)
@@ -511,6 +512,7 @@ void FAudio_close_out(FAudioIOStreamOut *io)
 	FAudio_free(io);
 }
 #endif /* FAUDIO_DUMP_VOICES */
+#endif
 
 /* UTF8->UTF16 Conversion, taken from PhysicsFS */
 

--- a/src/stb.h
+++ b/src/stb.h
@@ -207,7 +207,7 @@ CREDITS
  * binding various stdlib functions stb.h uses to FAudio's stdlib.
  * -flibit
  */
-#ifndef FAUDIO_UNKNOWN_PLATFORM
+#ifndef FAUDIO_PLATFORM_CALLBACKS
 #ifdef memcpy /* Thanks Apple! */
 #undef memcpy
 #endif


### PR DESCRIPTION
Even with the engine procedure callback, Wine has to swap it to another
thread in order for the application-provided callbacks to be executed in
the context of a Wine thread, and not the SDL audio created thread.

This adds unnecessary complexity, where we can simply provide some
platform callbacks to create threads and synchronization primitives
directly instead.

This will also allow Wine get rid of the FAudio SDL2 dependency, which
is desirable, considering we'll ultimately need FAudio built as PE.

@aeikum told me that this was discussed before and the current
approach was preferred at the time, but maybe now that the API is more
stable it can be reconsidered?