### PR TITLE
Don't assert that F3DAudioCalculate channel count match instance count.

### DIFF
--- a/src/F3DAudio.c
+++ b/src/F3DAudio.c
@@ -311,7 +311,7 @@ F3DAUDIOAPI uint8_t F3DAudioCheckCalculateParams(
 	uint32_t Flags,
 	F3DAUDIO_DSP_SETTINGS *pDSPSettings
 ) {
-	uint32_t i, ChannelCount;
+	uint32_t i;
 
 	POINTER_CHECK(Instance);
 	POINTER_CHECK(pListener);
@@ -345,11 +345,6 @@ F3DAUDIOAPI uint8_t F3DAudioCheckCalculateParams(
 		);
 	}
 
-	ChannelCount = SPEAKERCOUNT(Instance);
-	PARAM_CHECK(
-		pDSPSettings->DstChannelCount == ChannelCount,
-		"Invalid channel count, DSP settings and speaker configuration must agree"
-	);
 	PARAM_CHECK(
 		pDSPSettings->SrcChannelCount == pEmitter->ChannelCount,
 		"Invalid channel count, DSP settings and emitter must agree"


### PR DESCRIPTION
This assertion is triggered by Guilty Gear Strive, after it has
called X3DAudioInitialize with a channel mask set to 3, and then calls
X3DAudioCalculate with DstChannelCount set to 6.

A simple program which does the same runs fine on Windows. I'm not completely sure to see why this assertion is there, as the instance channel count doesn't seem to be used anywhere else.