### PR TITLE
Include malloc.h for alloca on Win32 platform.

### DIFF
--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -32,6 +32,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <malloc.h>
 #include <math.h>
 #include <assert.h>
 #include <inttypes.h>


### PR DESCRIPTION
MinGW somehow seems to get it from somewhere else but that's not right
and Wine headers (or MSVC) don't.