### PR TITLE
Fix unbalanced parentheses in FAudio.c

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -2455,7 +2455,7 @@ uint32_t FAudioSourceVoice_SubmitSourceBuffer(
 #ifdef HAVE_WMADEC
 	FAudio_assert(	(voice->src.wmadec != NULL && (pBufferWMA != NULL ||
 					(voice->src.format->wFormatTag == FAUDIO_FORMAT_XMAUDIO2 ||
-					 voice->src.format->wFormatTag == FAUDIO_FORMAT_EXTENSIBLE)) ||
+					 voice->src.format->wFormatTag == FAUDIO_FORMAT_EXTENSIBLE))) ||
 			(voice->src.wmadec == NULL && (pBufferWMA == NULL && voice->src.format->wFormatTag != FAUDIO_FORMAT_XMAUDIO2))	);
 #endif /* HAVE_WMADEC */
 


### PR DESCRIPTION
Commit b5916945b90d ("Dont assert on WMA buffer and
FAUDIO_FORMAT_EXTENSIBLE type") introduced unbalanced parentheses,
which breaks builds using HAVE_WMADEC.

Given the change made in the aforementioned commit, this balances
parentheses by adding a third closing parenthesis after the reworked
conditions.

Signed-off-by: Stephen Kitt <steve@sk2.org>