### PR TITLE
Return a PCM format by default in Win32 GetDeviceDetails

### DIFF
--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -411,13 +411,14 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 	uint32_t index,
 	FAudioDeviceDetails *details
 ) {
+	WAVEFORMATEX *format, *obtained;
 	WAVEFORMATEXTENSIBLE *ext;
-	WAVEFORMATEX *format;
 	IAudioClient *client;
 	IMMDevice *device;
 	uint32_t ret = 0;
 	HRESULT hr;
 	WCHAR *str;
+	GUID sub;
 
 	FAudio_memset(details, 0, sizeof(FAudioDeviceDetails));
 	if (index > 0) return FAUDIO_E_INVALID_CALL;
@@ -452,6 +453,28 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 
 	hr = IAudioClient_GetMixFormat(client, &format);
 	FAudio_assert(!FAILED(hr) && "Failed to get audio client mix format!");
+
+	if (format->wFormatTag == WAVE_FORMAT_EXTENSIBLE)
+	{
+		ext = (WAVEFORMATEXTENSIBLE *)format;
+		sub = ext->SubFormat;
+		FAudio_memcpy(
+			&ext->SubFormat,
+			&DATAFORMAT_SUBTYPE_PCM,
+			sizeof(GUID)
+		);
+
+		hr = IAudioClient_IsFormatSupported(client, AUDCLNT_SHAREMODE_SHARED, format, &obtained);
+		if (FAILED(hr))
+		{
+			ext->SubFormat = sub;
+		}
+		else if (obtained)
+		{
+			CoTaskMemFree(format);
+			format = obtained;
+		}
+	}
 
 	details->OutputFormat.Format.wFormatTag = format->wFormatTag;
 	details->OutputFormat.Format.nChannels = format->nChannels;

--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -473,6 +473,8 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 		);
 	}
 
+	CoTaskMemFree(format);
+
 	IAudioClient_Release(client);
 
 	IMMDevice_Release(device);


### PR DESCRIPTION
Far Cry 4 expects it, and testing shows that it's apparently the case on Windows (https://testbot.winehq.org/JobDetails.pl?Key=104269) even though WASAPI default mix format is IEEE_FLOAT.