### PR TITLE
Clear the end of WMA buffer when decoded output is too short.

### DIFF
--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -1191,8 +1191,8 @@ static void FAudio_INTERNAL_DecodeWMAMF(
 	uint32_t samples
 ) {
 	const FAudioWaveFormatExtensible *wfx = (FAudioWaveFormatExtensible *)voice->src.format;
+	size_t samples_pos, samples_size, copy_size = 0;
 	struct FAudioWMADEC *impl = voice->src.wmadec;
-	size_t samples_pos, samples_size, copy_size;
 	HRESULT hr;
 
 	LOG_FUNC_ENTER(voice->audio)
@@ -1264,8 +1264,12 @@ static void FAudio_INTERNAL_DecodeWMAMF(
 		impl->input_size = 0;
 	}
 
-	copy_size = FAudio_clamp(impl->output_pos - samples_pos, 0, samples_size);
-	FAudio_memcpy(decodeCache, impl->output_buf + samples_pos, copy_size);
+	if (impl->output_pos > samples_pos)
+	{
+		copy_size = FAudio_min(impl->output_pos - samples_pos, samples_size);
+		FAudio_memcpy(decodeCache, impl->output_buf + samples_pos, copy_size);
+	}
+	FAudio_zero(decodeCache + copy_size, samples_size - copy_size);
 	LOG_INFO(
 		voice->audio,
 		"decoded %x / %x bytes, copied %x / %x bytes",


### PR DESCRIPTION
Instead of copying garbage when `output_pos < samples_pos` and `output_pos - samples_pos` overflows, as they are both unsigned.