### PR TITLE
Fix hard-crash when no audio devices are present on win32

### DIFF
--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -399,6 +399,12 @@ uint32_t FAudio_PlatformGetDeviceCount(void)
 		eConsole,
 		&device
 	);
+
+	if (hr == E_NOTFOUND) {
+		FAudio_PlatformRelease();
+		return 0;
+	}
+
 	FAudio_assert(!FAILED(hr) && "Failed to get default audio endpoint!");
 
 	IMMDevice_Release(device);


### PR DESCRIPTION
Behaviour with the SDL2 backend is to return 0 here, and the managed side throws a `NoAudioHardwareException`