### PR TITLE
Set fallback dwChannelMask in device details for non-extensible formats

### DIFF
--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -501,6 +501,9 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 			sizeof(GUID)
 		);
 	}
+	else {
+		details->OutputFormat.dwChannelMask = GetMask(format->nChannels);
+	}
 
 	CoTaskMemFree(format);
 

--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -501,7 +501,8 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 			sizeof(GUID)
 		);
 	}
-	else {
+	else
+	{
 		details->OutputFormat.dwChannelMask = GetMask(format->nChannels);
 	}
 


### PR DESCRIPTION
When using the win32 backend, and the primary sound output device returns a `WAVEFORMATEX` (eg `FAUDIO_FORMAT_IEEE_FLOAT`) from `IAudioClient_GetMixFormat`, no speaker mask gets set. This causes `F3DAudioInitialize8` to fail an assertion that there must be a non-zero speakermask.

```
Assertion failed: speakerMaskIsValid == 1 && "SpeakerChannelMask is invalid. Needs to be one of" " MONO, STEREO, QUAD, 2POINT1, 4POINT1, 5POINT1, 7POINT1," " SURROUND, 5POINT1_SURROUND, or 7POINT1_SURROUND.", file C:\Users\covers1624\Programming\tModLoader\FNA\lib\FAudio\src\F3DAudio.c, line 133 
```

I used the fallback based on number of channels, so 3d audio should work correctly most of the time.