### PR TITLE
Send WAVEBANKPREPARED notifications.

### DIFF
--- a/src/FACT_internal.h
+++ b/src/FACT_internal.h
@@ -440,6 +440,7 @@ struct FACTAudioEngine
 	void *sb_context;
 	void *wb_context;
 	void *wave_context;
+	LinkedList *wb_notifications_list;
 
 	/* Settings handle */
 	void *settings;


### PR DESCRIPTION
The notifications are not sent immediately, but pushed to a queue
and sent at the next DoWork() call. This seems to correspond to what
happens on Windows.