### PR TITLE
Update to SDL 2.24.0.

### DIFF
--- a/README
+++ b/README
@@ -15,7 +15,7 @@ library via FAudio#, which you can find in the 'csharp/' directory.
 
 Dependencies
 ------------
-FAudio depends solely on SDL 2.0.9 or newer.
+FAudio depends solely on SDL 2.24.0 or newer.
 FAudio never explicitly uses the C runtime.
 
 Building FAudio


### PR DESCRIPTION
- 2.1 and 4.1 audio is now supported
- DirectSound is now prioritized over WASAPI
- The PulseAudio samples hack has been removed
- The non-power-of-two samples hack for Emscripten/OSS has also been removed
- GetDeviceDetails(0) now uses SDL_GetDefaultAudioInfo, obsoleting our hack

Trust me, you want _all_ of these fixes. Update your SDL version!