### PR TITLE
Fix access violation on win32 thread shutdown

### DIFF
--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -582,7 +582,7 @@ FAudioThread FAudio_PlatformCreateThread(
 void FAudio_PlatformWaitThread(FAudioThread thread, int32_t *retval)
 {
 	WaitForSingleObject(thread, INFINITE);
-	GetExitCodeThread(thread, (DWORD *)retval);
+	if (retval != NULL) GetExitCodeThread(thread, (DWORD *)retval);
 }
 
 void FAudio_PlatformThreadPriority(FAudioThreadPriority priority)


### PR DESCRIPTION
The SDL2 implementation of `GetExitCodeThread` allows passing `NULL` to ignore the exit code. The WINAPI function does not. 