### PR TITLE
CMake: add feature macros for usleep for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ endif()
 # tests/ Folder
 if(BUILD_TESTS)
 	add_executable(faudio_tests tests/xaudio2.c)
+	target_compile_definitions(faudio_tests PRIVATE _DEFAULT_SOURCE _BSD_SOURCE)
 	target_link_libraries(faudio_tests PRIVATE FAudio)
 endif()
 


### PR DESCRIPTION
usleep() from unistd.h requires _BSD_SOURCE (required on musl libc) (+_DEFAULT_SOURCE for glibc)