### PR TITLE
Unbreak build on Darwin PowerPC

### DIFF
--- a/src/FAudio_internal_simd.c
+++ b/src/FAudio_internal_simd.c
@@ -48,7 +48,7 @@
 
 	/* AArch64 guarantees NEON. */
 	#define NEED_SCALAR_CONVERTER_FALLBACKS 0
-#elif __MACOSX__
+#elif __MACOSX__ && !defined(__POWERPC__)
 	/* Some build systems may need to specify this. */
 	#if !defined(__SSE2__) && !defined(__ARM_NEON__)
 	#error macOS does not have SSE2/NEON? Bad compiler?


### PR DESCRIPTION
There are no SSE2 and NEON on PowerPC, for obvious reasons.