### PR TITLE
SDL: set the playback format with native endianness

### DIFF
--- a/src/FAudio_platform_sdl2.c
+++ b/src/FAudio_platform_sdl2.c
@@ -149,7 +149,7 @@ void FAudio_PlatformInit(
 
 	/* Build the device spec */
 	want.freq = mixFormat->Format.nSamplesPerSec;
-	want.format = AUDIO_F32;
+	want.format = AUDIO_F32SYS;
 	want.channels = mixFormat->Format.nChannels;
 	want.silence = 0;
 	want.callback = FAudio_INTERNAL_MixCallback;


### PR DESCRIPTION
This fixes sound playback on big-endian machines.

Fixes: #329