### PR TITLE
Don't destroy voice when it is output to other voices

### DIFF
--- a/include/FAudio.h
+++ b/include/FAudio.h
@@ -1064,6 +1064,11 @@ FAUDIOAPI void FAudioVoice_GetOutputMatrix(
 /* Removes this voice from the audio graph and frees memory. */
 FAUDIOAPI void FAudioVoice_DestroyVoice(FAudioVoice *voice);
 
+/*
+ * Returns S_OK on success and E_FAIL if voice could not be destroyed (e. g., because it is in use).
+ */
+FAUDIOAPI uint32_t FAudioVoice_DestroyVoiceSafeEXT(FAudioVoice *voice);
+
 /* FAudioSourceVoice Interface */
 
 /* Starts processing for a source voice.

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -2265,10 +2265,70 @@ void FAudioVoice_GetOutputMatrix(
 	LOG_API_EXIT(voice->audio)
 }
 
-void FAudioVoice_DestroyVoice(FAudioVoice *voice)
+static uint32_t check_for_sends_to_voice(FAudioVoice *voice)
 {
+	FAudio *audio = voice->audio;
+	uint32_t ret = 0;
+	FAudioSourceVoice *source;
+	FAudioSubmixVoice *submix;
+	LinkedList *list;
 	uint32_t i;
+
+	FAudio_PlatformLockMutex(audio->sourceLock);
+	list = audio->sources;
+	while (list != NULL)
+	{
+		source = (FAudioSourceVoice*) list->entry;
+		for (i = 0; i < source->sends.SendCount; i += 1)
+			if (source->sends.pSends[i].pOutputVoice == voice)
+			{
+				ret = 0x80004005; /* E_FAIL */
+				break;
+			}
+		if (ret)
+			break;
+		list = list->next;
+	}
+	FAudio_PlatformUnlockMutex(audio->sourceLock);
+
+	if (ret)
+		return ret;
+
+	FAudio_PlatformLockMutex(audio->submixLock);
+	list = audio->submixes;
+	while (list != NULL)
+	{
+		submix = (FAudioSubmixVoice*) list->entry;
+		for (i = 0; i < submix->sends.SendCount; i += 1)
+			if (submix->sends.pSends[i].pOutputVoice == voice)
+			{
+				ret = 0x80004005; /* E_FAIL */
+				break;
+			}
+		if (ret)
+			break;
+		list = list->next;
+	}
+	FAudio_PlatformUnlockMutex(audio->submixLock);
+
+	return ret;
+}
+
+uint32_t FAudioVoice_DestroyVoiceSafeEXT(FAudioVoice *voice)
+{
+	uint32_t i, ret;
 	LOG_API_ENTER(voice->audio)
+
+	if ((ret = check_for_sends_to_voice(voice)))
+	{
+		LOG_ERROR(
+			voice->audio,
+			"Voice %p is an output for other voice(s)",
+			voice
+		)
+		LOG_API_EXIT(voice->audio)
+		return ret;
+	}
 
 	/* TODO: Check for dependencies and remove from audio graph first! */
 	FAudio_OPERATIONSET_ClearAllForVoice(voice);
@@ -2443,6 +2503,12 @@ void FAudioVoice_DestroyVoice(FAudioVoice *voice)
 	LOG_API_EXIT(voice->audio)
 	FAudio_Release(voice->audio);
 	voice->audio->pFree(voice);
+	return 0;
+}
+
+void FAudioVoice_DestroyVoice(FAudioVoice *voice)
+{
+	FAudioVoice_DestroyVoiceSafeEXT(voice);
 }
 
 /* FAudioSourceVoice Interface */

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -212,9 +212,9 @@ void LinkedList_RemoveEntry(
 	FAudioFreeFunc pFree
 ) {
 	LinkedList *latest, *prev;
+	FAudio_PlatformLockMutex(lock);
 	latest = *start;
 	prev = latest;
-	FAudio_PlatformLockMutex(lock);
 	while (latest != NULL)
 	{
 		if (latest->entry == toRemove)


### PR DESCRIPTION
Cosmoteer (Steam game id 799600) sometimes destroys a submix voice which is an output for another voice. That leads to use after free access in audio client thread performing mixing which leads to obscure random crashes.

MS docs [1] suggest that IXAudio2Voice::DestroyVoice fails in such a case ("If any other voice is currently sending audio to this voice, the method fails.").

I made a test on top of Wine xaudio2 tests which indirectly confirms that (attaching a patch). I don't immediately see a direct way to test if DestroyVoice actually failed or not as it doesn't return any status. However, I found that after successful voice destruction IXAudio2SubmixVoice_GetVoiceDetails() for that voice crashes on Windows and using this fact to probe for actual voice destruction (the first one in the test doesn't crash as, the second one guarded with if (0) crashes for me on Win10).

1. https://learn.microsoft.com/en-us/windows/win32/api/xaudio2/nf-xaudio2-ixaudio2voice-destroyvoice

[0001-xaudio2-tests-Test-destroying-a-voice-which-is-an-ou.txt](https://github.com/FNA-XNA/FAudio/files/14413256/0001-xaudio2-tests-Test-destroying-a-voice-which-is-an-ou.txt)
