### PR TITLE
build: fix __attribute__((aligned(x))) on gcc/clang

### DIFF
--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -211,8 +211,8 @@ extern void FAudio_Log(char const *msg);
 #endif
 
 /* Alignment macro for gcc/clang/msvc */
-#if defined(__GNUC__) || defined(__clang__)
-#define ALIGN(type, boundary) type __attribute_((aligned(boundary)))
+#if defined(__clang__) || defined(__GNUC__)
+#define ALIGN(type, boundary) type __attribute__((aligned(boundary)))
 #elif defined(_MSC_VER)
 #define ALIGN(type, boundary) __declspec(align(boundary)) type
 #else


### PR DESCRIPTION
This is a followup on 81d5a24 (build: fix building with MSVC,
2024-03-07).

Fix the missing trailing _ in __attribute__ for
__attribute((aligned(x))).