### PR TITLE
build: fix dependency on SDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,11 @@ install(
 include(cmake/JoinPaths.cmake)
 join_paths(FAUDIO_PKGCONF_LIBDIR "\${prefix}" "${CMAKE_INSTALL_LIBDIR}")
 join_paths(FAUDIO_PKGCONF_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+
+if(NOT PLATFORM_WIN32)
+	set(PC_REQUIRES_PRIVATE "Requires.private: sdl2")
+endif()
+
 configure_file(
 	"${PROJECT_SOURCE_DIR}/cmake/${PROJECT_NAME}.pc.in"
 	${PROJECT_BINARY_DIR}/generated/${PROJECT_NAME}.pc

--- a/cmake/FAudio.pc.in
+++ b/cmake/FAudio.pc.in
@@ -7,6 +7,7 @@ Name: @PROJECT_NAME@
 URL: https://github.com/FNA-XNA/FAudio
 Description: Accuracy-focused XAudio reimplementation for open platforms
 Version: @LIB_VERSION@
+@PC_REQUIRES_PRIVATE@
 
 Libs: -L${libdir} -l@PROJECT_NAME@
 Cflags: -I${includedir} @PLATFORM_CFLAGS@

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,5 +1,10 @@
 @PACKAGE_INIT@
 
+if(NOT "@PLATFORM_WIN32@")
+	include(CMakeFindDependencyMacro)
+	find_dependency(SDL2 CONFIG)
+endif()
+
 include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets.cmake")
 check_required_components("@CMAKE_PROJECT_NAME@")
 


### PR DESCRIPTION
This is a followup on 81d5a24 (build: fix building with MSVC, 2024-03-07) and 68a555e (build: fix __attribute__((aligned(x))) on gcc/clang, 2024-03-09) for the purposes of creating a vcpkg FAudio port.

Add a `Requires.private: sdl2` to the pkgconf file for the SDL2 dependency when not using PLATFORM_WIN32.

Add the SDL2 dependency to the generated cmake config file when not using PLATFORM_WIN32 as well.