### PR TITLE
Fix deadlock in voice callbacks

### DIFF
--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -383,6 +383,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 			if (	voice->src.callback != NULL &&
 				voice->src.callback->OnBufferStart != NULL	)
 			{
+				FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+				LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+				FAudio_PlatformUnlockMutex(voice->sendLock);
+				LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
 				FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 				LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -393,6 +399,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 
 				FAudio_PlatformLockMutex(voice->audio->sourceLock);
 				LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+				FAudio_PlatformLockMutex(voice->sendLock);
+				LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+				FAudio_PlatformLockMutex(voice->src.bufferLock);
+				LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 			}
 		}
 
@@ -442,6 +454,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 				if (	voice->src.callback != NULL &&
 					voice->src.callback->OnLoopEnd != NULL	)
 				{
+					FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+					FAudio_PlatformUnlockMutex(voice->sendLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
 					FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 					LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -452,6 +470,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 
 					FAudio_PlatformLockMutex(voice->audio->sourceLock);
 					LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+					FAudio_PlatformLockMutex(voice->sendLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+					FAudio_PlatformLockMutex(voice->src.bufferLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 				}
 			}
 			else
@@ -504,6 +528,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 				/* Callbacks */
 				if (voice->src.callback != NULL)
 				{
+					FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+					FAudio_PlatformUnlockMutex(voice->sendLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
 					FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 					LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -522,6 +552,15 @@ static void FAudio_INTERNAL_DecodeBuffers(
 						);
 					}
 
+					FAudio_PlatformLockMutex(voice->audio->sourceLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+					FAudio_PlatformLockMutex(voice->sendLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+					FAudio_PlatformLockMutex(voice->src.bufferLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
+
 					/* One last chance at redemption */
 					if (buffer == NULL && voice->src.bufferList != NULL)
 					{
@@ -531,14 +570,29 @@ static void FAudio_INTERNAL_DecodeBuffers(
 
 					if (buffer != NULL && voice->src.callback->OnBufferStart != NULL)
 					{
+						FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+						LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+						FAudio_PlatformUnlockMutex(voice->sendLock);
+						LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
+						FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
+						LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
+
 						voice->src.callback->OnBufferStart(
 							voice->src.callback,
 							buffer->pContext
 						);
-					}
 
-					FAudio_PlatformLockMutex(voice->audio->sourceLock);
-					LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+						FAudio_PlatformLockMutex(voice->audio->sourceLock);
+						LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+						FAudio_PlatformLockMutex(voice->sendLock);
+						LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+						FAudio_PlatformLockMutex(voice->src.bufferLock);
+						LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
+					}
 				}
 
 				voice->audio->pFree(toDelete);
@@ -1250,6 +1304,9 @@ static void FAudio_INTERNAL_FlushPendingBuffers(FAudioSourceVoice *voice)
 
 		if (voice->src.callback != NULL && voice->src.callback->OnBufferEnd != NULL)
 		{
+			FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+			LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
 			FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 			LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -1260,6 +1317,9 @@ static void FAudio_INTERNAL_FlushPendingBuffers(FAudioSourceVoice *voice)
 
 			FAudio_PlatformLockMutex(voice->audio->sourceLock);
 			LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+			FAudio_PlatformLockMutex(voice->src.bufferLock);
+			LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 		}
 		voice->audio->pFree(entry);
 	}

--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -627,10 +627,10 @@ void FAudio_INTERNAL_debug_fmt(
 #define LOG_FUNC_ENTER(engine) PRINT_DEBUG(engine, FUNC_CALLS, "FUNC Enter", "%s", __func__)
 #define LOG_FUNC_EXIT(engine) PRINT_DEBUG(engine, FUNC_CALLS, "FUNC Exit", "%s", __func__)
 /* TODO: LOG_TIMING */
-#define LOG_MUTEX_CREATE(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Create", "%p", mutex)
-#define LOG_MUTEX_DESTROY(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Destroy", "%p", mutex)
-#define LOG_MUTEX_LOCK(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Lock", "%p", mutex)
-#define LOG_MUTEX_UNLOCK(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Unlock", "%p", mutex)
+#define LOG_MUTEX_CREATE(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Create", "%p (%s)", mutex, #mutex)
+#define LOG_MUTEX_DESTROY(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Destroy", "%p (%s)", mutex, #mutex)
+#define LOG_MUTEX_LOCK(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Lock", "%p (%s)", mutex, #mutex)
+#define LOG_MUTEX_UNLOCK(engine, mutex) PRINT_DEBUG(engine, LOCKS, "Mutex Unlock", "%p (%s)", mutex, #mutex)
 /* TODO: LOG_MEMORY */
 /* TODO: LOG_STREAMING */
 


### PR DESCRIPTION
This is an attempt to fix a Wine bug. Downstream PR: https://gitlab.winehq.org/wine/wine/-/merge_requests/5424

Deadlock was being caused by the fact that some private FAudio routines hold internal mutexes while calling application callbacks. This may result in a deadlock because app might have a huge global mutex that is locked both by callbacks and by some code that e.g. submits new buffers to XAudio.