### PR TITLE
Fix deadlock in voice callbacks

### DIFF
--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -383,6 +383,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 			if (	voice->src.callback != NULL &&
 				voice->src.callback->OnBufferStart != NULL	)
 			{
+				FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+				LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+				FAudio_PlatformUnlockMutex(voice->sendLock);
+				LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
 				FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 				LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -393,6 +399,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 
 				FAudio_PlatformLockMutex(voice->audio->sourceLock);
 				LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+				FAudio_PlatformLockMutex(voice->sendLock);
+				LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+				FAudio_PlatformLockMutex(voice->src.bufferLock);
+				LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 			}
 		}
 
@@ -442,6 +454,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 				if (	voice->src.callback != NULL &&
 					voice->src.callback->OnLoopEnd != NULL	)
 				{
+					FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+					FAudio_PlatformUnlockMutex(voice->sendLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
 					FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 					LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -452,6 +470,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 
 					FAudio_PlatformLockMutex(voice->audio->sourceLock);
 					LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+					FAudio_PlatformLockMutex(voice->sendLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+					FAudio_PlatformLockMutex(voice->src.bufferLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 				}
 			}
 			else
@@ -504,6 +528,12 @@ static void FAudio_INTERNAL_DecodeBuffers(
 				/* Callbacks */
 				if (voice->src.callback != NULL)
 				{
+					FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+					FAudio_PlatformUnlockMutex(voice->sendLock);
+					LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
 					FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 					LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -522,6 +552,15 @@ static void FAudio_INTERNAL_DecodeBuffers(
 						);
 					}
 
+					FAudio_PlatformLockMutex(voice->audio->sourceLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+					FAudio_PlatformLockMutex(voice->sendLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+					FAudio_PlatformLockMutex(voice->src.bufferLock);
+					LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
+
 					/* One last chance at redemption */
 					if (buffer == NULL && voice->src.bufferList != NULL)
 					{
@@ -531,14 +570,29 @@ static void FAudio_INTERNAL_DecodeBuffers(
 
 					if (buffer != NULL && voice->src.callback->OnBufferStart != NULL)
 					{
+						FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+						LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
+						FAudio_PlatformUnlockMutex(voice->sendLock);
+						LOG_MUTEX_UNLOCK(voice->audio, voice->sendLock)
+
+						FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
+						LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
+
 						voice->src.callback->OnBufferStart(
 							voice->src.callback,
 							buffer->pContext
 						);
-					}
 
-					FAudio_PlatformLockMutex(voice->audio->sourceLock);
-					LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+						FAudio_PlatformLockMutex(voice->audio->sourceLock);
+						LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+						FAudio_PlatformLockMutex(voice->sendLock);
+						LOG_MUTEX_LOCK(voice->audio, voice->sendLock)
+
+						FAudio_PlatformLockMutex(voice->src.bufferLock);
+						LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
+					}
 				}
 
 				voice->audio->pFree(toDelete);
@@ -1250,6 +1304,9 @@ static void FAudio_INTERNAL_FlushPendingBuffers(FAudioSourceVoice *voice)
 
 		if (voice->src.callback != NULL && voice->src.callback->OnBufferEnd != NULL)
 		{
+			FAudio_PlatformUnlockMutex(voice->src.bufferLock);
+			LOG_MUTEX_UNLOCK(voice->audio, voice->src.bufferLock)
+
 			FAudio_PlatformUnlockMutex(voice->audio->sourceLock);
 			LOG_MUTEX_UNLOCK(voice->audio, voice->audio->sourceLock)
 
@@ -1260,6 +1317,9 @@ static void FAudio_INTERNAL_FlushPendingBuffers(FAudioSourceVoice *voice)
 
 			FAudio_PlatformLockMutex(voice->audio->sourceLock);
 			LOG_MUTEX_LOCK(voice->audio, voice->audio->sourceLock)
+
+			FAudio_PlatformLockMutex(voice->src.bufferLock);
+			LOG_MUTEX_LOCK(voice->audio, voice->src.bufferLock)
 		}
 		voice->audio->pFree(entry);
 	}

--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -1055,7 +1055,7 @@ FAUDIOAPI uint32_t XNA_GetSongEnded()
 		return 1;
 	}
 	FAudioSourceVoice_GetState(songVoice, &state, 0);
-	return state.BuffersQueued == 0;
+	return state.BuffersQueued == 0 && state.SamplesPlayed == 0;
 }
 
 FAUDIOAPI void XNA_EnableVisualization(uint32_t enable)

--- a/src/XNA_Song.c
+++ b/src/XNA_Song.c
@@ -325,7 +325,7 @@ FAUDIOAPI uint32_t XNA_GetSongEnded()
 		return 1;
 	}
 	FAudioSourceVoice_GetState(songVoice, &state, 0);
-	return state.BuffersQueued == 0;
+	return state.BuffersQueued == 0 && state.SamplesPlayed == 0;
 }
 
 FAUDIOAPI void XNA_EnableVisualization(uint32_t enable)


### PR DESCRIPTION
Second attempt. Previous here: https://github.com/FNA-XNA/FAudio/pull/337

Now that we release buffer lock before executing callbacks, some code from another thread can get scheduled between mutex unlock and callback call and observe empty buffer queue right before callback puts a new buffer there. XNA_Song determines the end of the song by simply checking if the queue is empty, which may lead to random playback breaks.

Not sure how to properly check for the song end but the buffer decoding function also zeroes out total samples counter when it finishes a EOS-flagged buffer so checking if that counter is zero should cut it... probably?