### PR TITLE
win32: Always check the return value of GetDefaultAudioEndpoint

### DIFF
--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -271,6 +271,10 @@ void FAudio_PlatformInit(
 		eConsole,
 		&device
 	);
+	if (hr == E_NOTFOUND) {
+		FAudio_PlatformRelease();
+		return FAUDIO_E_INVALID_CALL;
+	}
 	FAudio_assert(!FAILED(hr) && "Failed to get default audio endpoint!");
 
 	hr = IMMDevice_Activate(
@@ -451,6 +455,10 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 		eConsole,
 		&device
 	);
+	if (hr == E_NOTFOUND) {
+		FAudio_PlatformRelease();
+		return FAUDIO_E_INVALID_CALL;
+	}
 	FAudio_assert(!FAILED(hr) && "Failed to get default audio endpoint!");
 
 	details->Role = FAudioGlobalDefaultDevice;


### PR DESCRIPTION
And don't crash if the computer doesn't have any audio devices.

Fixes #347