### PR TITLE
build: separate shared and static import targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,14 @@ if(INSTALL_MINGW_DEPENDENCIES)
 	include(cmake/install_shared_libs.cmake)
 endif()
 
+set(target FAudio-shared)
+
+if(NOT BUILD_SHARED_LIBS)
+	set(target FAudio-static)
+endif()
+
 # Source lists
-add_library(FAudio
+add_library(${target}
 	# Public Headers
 	include/F3DAudio.h
 	include/FACT3D.h
@@ -106,14 +112,14 @@ add_library(FAudio
 )
 
 if(PLATFORM_WIN32)
-	target_link_libraries(FAudio PRIVATE dxguid uuid winmm ole32 advapi32 user32 mfplat mfreadwrite mfuuid propsys)
-	target_compile_definitions(FAudio PUBLIC FAUDIO_WIN32_PLATFORM)
-	target_compile_definitions(FAudio PRIVATE HAVE_WMADEC=1)
+	target_link_libraries(${target} PRIVATE dxguid uuid winmm ole32 advapi32 user32 mfplat mfreadwrite mfuuid propsys)
+	target_compile_definitions(${target} PUBLIC FAUDIO_WIN32_PLATFORM)
+	target_compile_definitions(${target} PRIVATE HAVE_WMADEC=1)
 	set(PLATFORM_CFLAGS "-DFAUDIO_WIN32_PLATFORM")
 	set(XNASONG OFF)
 else()
 	if(BUILD_SDL3)
-		target_compile_definitions(FAudio PUBLIC FAUDIO_SDL3_PLATFORM)
+		target_compile_definitions(${target} PUBLIC FAUDIO_SDL3_PLATFORM)
 		set(PLATFORM_CFLAGS "-DFAUDIO_SDL3_PLATFORM")
 	else()
 		set(PLATFORM_CFLAGS)
@@ -122,39 +128,39 @@ endif()
 
 # Only disable DebugConfiguration in release builds
 if(NOT FORCE_ENABLE_DEBUGCONFIGURATION)
-	target_compile_definitions(FAudio PRIVATE $<$<CONFIG:Release>:FAUDIO_DISABLE_DEBUGCONFIGURATION>)
+	target_compile_definitions(${target} PRIVATE $<$<CONFIG:Release>:FAUDIO_DISABLE_DEBUGCONFIGURATION>)
 endif()
 
 # FAudio_assert Customization
 if(LOG_ASSERTIONS)
-	target_compile_definitions(FAudio PUBLIC FAUDIO_LOG_ASSERTIONS)
+	target_compile_definitions(${target} PUBLIC FAUDIO_LOG_ASSERTIONS)
 endif()
 
 # FAudio folders as includes, for other targets to consume
-target_include_directories(FAudio PUBLIC
+target_include_directories(${target} PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
 # MinGW builds should statically link libgcc
 if(MINGW)
-	target_link_libraries(FAudio PRIVATE -static-libgcc)
+	target_link_libraries(${target} PRIVATE -static-libgcc)
 endif()
 
 # Soname
-set_target_properties(FAudio PROPERTIES OUTPUT_NAME "FAudio"
+set_target_properties(${target} PROPERTIES OUTPUT_NAME "FAudio"
 	VERSION ${LIB_VERSION}
 	SOVERSION ${LIB_MAJOR_VERSION}
 )
 
 # XNA_Song Support
 if(NOT XNASONG)
-	target_compile_definitions(FAudio PRIVATE DISABLE_XNASONG)
+	target_compile_definitions(${target} PRIVATE DISABLE_XNASONG)
 endif()
 
 # Dump source voices to RIFF WAVE files
 if(DUMP_VOICES)
-	target_compile_definitions(FAudio PRIVATE FAUDIO_DUMP_VOICES)
+	target_compile_definitions(${target} PRIVATE FAUDIO_DUMP_VOICES)
 endif()
 
 # SDL Dependency
@@ -163,8 +169,8 @@ if (PLATFORM_WIN32)
 elseif (BUILD_SDL3)
 	if (DEFINED SDL3_INCLUDE_DIRS AND DEFINED SDL3_LIBRARIES)
 		message(STATUS "using pre-defined SDL3 variables SDL3_INCLUDE_DIRS and SDL3_LIBRARIES")
-		target_include_directories(FAudio PUBLIC "$<BUILD_INTERFACE:${SDL3_INCLUDE_DIRS}>")
-		target_link_libraries(FAudio PUBLIC ${SDL3_LIBRARIES})
+		target_include_directories(${target} PUBLIC "$<BUILD_INTERFACE:${SDL3_INCLUDE_DIRS}>")
+		target_link_libraries(${target} PUBLIC ${SDL3_LIBRARIES})
 		if(INSTALL_MINGW_DEPENDENCIES)
 			install_shared_libs(${SDL3_LIBRARIES} DESTINATION bin NO_INSTALL_SYMLINKS)
 		endif()
@@ -173,20 +179,20 @@ elseif (BUILD_SDL3)
 		find_package(SDL3 CONFIG)
 		if (TARGET SDL3::SDL3)
 			message(STATUS "using TARGET SDL3::SDL3")
-			target_link_libraries(FAudio PUBLIC SDL3::SDL3)
+			target_link_libraries(${target} PUBLIC SDL3::SDL3)
 			if(INSTALL_MINGW_DEPENDENCIES)
 				install_shared_libs(TARGETS SDL3::SDL3 DESTINATION bin NO_INSTALL_SYMLINKS REQUIRED)
 			endif()
 		elseif (TARGET SDL3)
 			message(STATUS "using TARGET SDL3")
-			target_link_libraries(FAudio PUBLIC SDL3)
+			target_link_libraries(${target} PUBLIC SDL3)
 			if(INSTALL_MINGW_DEPENDENCIES)
 				install_shared_libs(TARGETS SDL3 DESTINATION bin NO_INSTALL_SYMLINKS REQUIRED)
 			endif()
 		else()
 			message(STATUS "no TARGET SDL3::SDL3, or SDL3, using variables")
-			target_include_directories(FAudio PUBLIC "$<BUILD_INTERFACE:${SDL3_INCLUDE_DIRS}>")
-			target_link_libraries(FAudio PUBLIC ${SDL3_LIBRARIES})
+			target_include_directories(${target} PUBLIC "$<BUILD_INTERFACE:${SDL3_INCLUDE_DIRS}>")
+			target_link_libraries(${target} PUBLIC ${SDL3_LIBRARIES})
 			if(INSTALL_MINGW_DEPENDENCIES)
 				install_shared_libs(${SDL3_LIBRARIES} DESTINATION bin NO_INSTALL_SYMLINKS)
 			endif()
@@ -194,8 +200,8 @@ elseif (BUILD_SDL3)
 	endif()
 elseif (DEFINED SDL2_INCLUDE_DIRS AND DEFINED SDL2_LIBRARIES)
 	message(STATUS "using pre-defined SDL2 variables SDL2_INCLUDE_DIRS and SDL2_LIBRARIES")
-	target_include_directories(FAudio PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
-	target_link_libraries(FAudio PUBLIC ${SDL2_LIBRARIES})
+	target_include_directories(${target} PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
+	target_link_libraries(${target} PUBLIC ${SDL2_LIBRARIES})
 	if(INSTALL_MINGW_DEPENDENCIES)
 		install_shared_libs(${SDL2_LIBRARIES} DESTINATION bin NO_INSTALL_SYMLINKS)
 	endif()
@@ -204,20 +210,20 @@ else()
 	find_package(SDL2 CONFIG)
 	if (TARGET SDL2::SDL2)
 		message(STATUS "using TARGET SDL2::SDL2")
-		target_link_libraries(FAudio PUBLIC SDL2::SDL2)
+		target_link_libraries(${target} PUBLIC SDL2::SDL2)
 		if(INSTALL_MINGW_DEPENDENCIES)
 			install_shared_libs(TARGETS SDL2::SDL2 DESTINATION bin NO_INSTALL_SYMLINKS REQUIRED)
 		endif()
 	elseif (TARGET SDL2)
 		message(STATUS "using TARGET SDL2")
-		target_link_libraries(FAudio PUBLIC SDL2)
+		target_link_libraries(${target} PUBLIC SDL2)
 		if(INSTALL_MINGW_DEPENDENCIES)
 			install_shared_libs(TARGETS SDL2 DESTINATION bin NO_INSTALL_SYMLINKS REQUIRED)
 		endif()
 	else()
 		message(STATUS "no TARGET SDL2::SDL2, or SDL2, using variables")
-		target_include_directories(FAudio PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
-		target_link_libraries(FAudio PUBLIC ${SDL2_LIBRARIES})
+		target_include_directories(${target} PUBLIC "$<BUILD_INTERFACE:${SDL2_INCLUDE_DIRS}>")
+		target_link_libraries(${target} PUBLIC ${SDL2_LIBRARIES})
 		if(INSTALL_MINGW_DEPENDENCIES)
 			install_shared_libs(${SDL2_LIBRARIES} DESTINATION bin NO_INSTALL_SYMLINKS)
 		endif()
@@ -242,7 +248,7 @@ if(BUILD_UTILS)
 		utils/uicommon/imstb_textedit.h
 		utils/uicommon/imstb_truetype.h
 	)
-	target_link_libraries(uicommon PUBLIC FAudio)
+	target_link_libraries(uicommon PUBLIC ${target})
 
 	# Shared WAV Resources
 	add_library(wavs STATIC utils/wavcommon/wavs.cpp)
@@ -252,11 +258,11 @@ if(BUILD_UTILS)
 
 	# These tools do NOT use uicommon
 	add_executable(testparse utils/testparse/testparse.c)
-	target_link_libraries(testparse PRIVATE FAudio)
+	target_link_libraries(testparse PRIVATE ${target})
 	add_executable(testxwma utils/testxwma/testxwma.cpp)
-	target_link_libraries(testxwma PRIVATE FAudio)
+	target_link_libraries(testxwma PRIVATE ${target})
 	add_executable(showriffheader utils/showriffheader/showriffheader.cpp)
-	target_link_libraries(showriffheader PRIVATE FAudio)
+	target_link_libraries(showriffheader PRIVATE ${target})
 
 	# These tools use uicommon, but NOT wavs
 	add_executable(facttool utils/facttool/facttool.cpp)
@@ -313,7 +319,7 @@ endif()
 if(BUILD_TESTS)
 	add_executable(faudio_tests tests/xaudio2.c)
 	target_compile_definitions(faudio_tests PRIVATE _DEFAULT_SOURCE _BSD_SOURCE)
-	target_link_libraries(faudio_tests PRIVATE FAudio)
+	target_link_libraries(faudio_tests PRIVATE ${target})
 endif()
 
 # Installation
@@ -324,9 +330,15 @@ install(
 	DESTINATION ${FAudio_INSTALL_INCLUDEDIR}
 )
 # Libraries...
+set(export ${PROJECT_NAME}-targets-shared)
+
+if(NOT BUILD_SHARED_LIBS)
+	set(export ${PROJECT_NAME}-targets-static)
+endif()
+
 install(
-	TARGETS ${PROJECT_NAME}
-	EXPORT ${PROJECT_NAME}-targets
+	TARGETS ${target}
+	EXPORT ${export}
 	INCLUDES DESTINATION ${FAudio_INSTALL_INCLUDEDIR}
 	RUNTIME DESTINATION ${FAudio_INSTALL_BINDIR}
 	LIBRARY DESTINATION ${FAudio_INSTALL_LIBDIR}
@@ -367,8 +379,9 @@ install(
 	FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/${PROJECT_NAME}Config.cmake
 	DESTINATION ${FAudio_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
+
 install(
-	EXPORT ${PROJECT_NAME}-targets
+	EXPORT ${export}
 	NAMESPACE ${PROJECT_NAME}::
 	DESTINATION ${FAudio_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )

--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -5,6 +5,20 @@ if(NOT "@PLATFORM_WIN32@")
 	find_dependency(SDL2 CONFIG)
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets.cmake")
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets-shared.cmake")
+	include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets-shared.cmake")
+	set(shared_target TRUE)
+endif()
+
+if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets-static.cmake")
+	include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@-targets-static.cmake")
+endif()
+
+if(shared_target)
+	add_library(@CMAKE_PROJECT_NAME@::@CMAKE_PROJECT_NAME@ ALIAS @CMAKE_PROJECT_NAME@::@CMAKE_PROJECT_NAME@-shared)
+else()
+	add_library(@CMAKE_PROJECT_NAME@::@CMAKE_PROJECT_NAME@ ALIAS @CMAKE_PROJECT_NAME@::@CMAKE_PROJECT_NAME@-static)
+endif()
+
 check_required_components("@CMAKE_PROJECT_NAME@")
 


### PR DESCRIPTION
Export the FAudio::FAudio-shared target when building a shared library and the FAudio::FAudio-static target when building a static library to separate target files so that both can be installed at the same time.

Alias FAudio::FAudio to the shared library if it is installed and the static library otherwise in the Config.