### PR TITLE
Account for difference in SDL2/SDL3 IO return values

### DIFF
--- a/src/FAudio_platform_sdl3.c
+++ b/src/FAudio_platform_sdl3.c
@@ -435,7 +435,7 @@ static size_t FAUDIOCALL FAudio_INTERNAL_ioread(
 	size_t size,
 	size_t count
 ) {
-	return SDL_ReadIO((SDL_IOStream*) data, dst, size * count);
+	return SDL_ReadIO((SDL_IOStream*) data, dst, size * count) / size;
 }
 
 static int64_t FAUDIOCALL FAudio_INTERNAL_ioseek(


### PR DESCRIPTION
The return values of these functions differ:

https://wiki.libsdl.org/SDL3/SDL_ReadIO
https://wiki.libsdl.org/SDL2/SDL_RWread

SDL2 returns the number of objects read, while SDL3 returns the number of bytes.  So, divide by the count of objects?