### PR TITLE
Add C# wrapper for part of FAPO and FAPOBase APIs

### DIFF
--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -947,9 +947,9 @@ public static class FAudio
 	public delegate uint LockForProcessFunc (
 		IntPtr fapo,
 		uint InputLockedParameterCount,
-		IntPtr pInputLockedParameters,
+		ref FAPOLockForProcessBufferParameters pInputLockedParameters,
 		uint OutputLockedParameterCount,
-		IntPtr pOutputLockedParameters
+		ref FAPOLockForProcessBufferParameters pOutputLockedParameters
 	);
 	[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 	public delegate void UnlockForProcessFunc (
@@ -1022,7 +1022,14 @@ public static class FAudio
 	};
 
 	[StructLayout(LayoutKind.Sequential)]
-	public unsafe struct FAPOProcessBufferParameters
+	public struct FAPOLockForProcessBufferParameters
+	{
+		public IntPtr pFormat;
+		uint MaxFrameCount;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct FAPOProcessBufferParameters
 	{
 		public IntPtr pBuffer;
 		public FAPOBufferFlags BufferFlags;

--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -27,7 +27,6 @@
 #region Using Statements
 using System;
 using System.Runtime.InteropServices;
-using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 #endregion
 


### PR DESCRIPTION
Just enough to be able to write your own spectrum analyzer.

It would be nice if FAudio took ownership of the registration properties passed in, so I could make them a `ref T` argument instead of an IntPtr you have to malloc and leak.