### PR TITLE
FACT: Comment out the 0ms fade handler.

### DIFF
--- a/src/FACT_internal.c
+++ b/src/FACT_internal.c
@@ -940,12 +940,18 @@ void FACT_INTERNAL_DestroySound(FACTSoundInstance *sound)
 
 void FACT_INTERNAL_BeginFadeOut(FACTSoundInstance *sound, uint16_t fadeOutMS)
 {
+	/* FIXME: Even for 0ms it seems to want to be in STOPPING for one frame.
+ 	 * Should we still destroy but defer state changes to the next frame?
+   	 * -flibit
+     	 */
+#if 0
 	if (fadeOutMS == 0)
 	{
 		/* No fade? Screw it, just delete us */
 		FACT_INTERNAL_DestroySound(sound);
 		return;
 	}
+#endif
 
 	sound->fadeType = 2; /* Out */
 	sound->fadeStart = FAudio_timems();


### PR DESCRIPTION
There's a 1-frame timing issue where two sounds in the same category being played consecutively should still have both sounds _technically_ playing, even if the fade time is 0ms.

Should fix #368.