### PR TITLE
Cmake: Fix Error with Cmake 4.0 and Warning with Cmake 3.31

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMake Project for FAudio
 # Written by @NeroBurner
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(FAudio C)
 
 # Options


### PR DESCRIPTION
With Cmake 4.0, Cmake generation makes an error when the minimum version is below 3.5
With Cmake 3.31, a warning is generated when the minimum version is below 3.10