### PR TITLE
Fixed documentation / assertion preventing using FAUDIO_1024_QUANTUM.

### DIFF
--- a/include/FAudio.h
+++ b/include/FAudio.h
@@ -511,7 +511,7 @@ FAUDIOAPI uint32_t FAudioLinkedVersion(void);
 /* This should be your first FAudio call.
  *
  * ppFAudio:		Filled with the FAudio core context.
- * Flags:		Can be 0 or FAUDIO_DEBUG_ENGINE.
+ * Flags:		Can be 0 or a combination of FAUDIO_DEBUG_ENGINE and FAUDIO_1024_QUANTUM.
  * XAudio2Processor:	Set this to FAUDIO_DEFAULT_PROCESSOR.
  *
  * Returns 0 on success.

--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -210,7 +210,7 @@ uint32_t FAudio_Initialize(
 	FAudioProcessor XAudio2Processor
 ) {
 	LOG_API_ENTER(audio)
-	FAudio_assert(Flags == 0 || Flags == FAUDIO_DEBUG_ENGINE);
+	FAudio_assert((Flags & ~(FAUDIO_DEBUG_ENGINE | FAUDIO_1024_QUANTUM)) == 0);
 	FAudio_assert(XAudio2Processor == FAUDIO_DEFAULT_PROCESSOR);
 
 	audio->initFlags = Flags;


### PR DESCRIPTION
This quantum is required for certain APOs, and enforcing this flag maintains better compatibility.