### PR TITLE
Making sure output debug messages are \n terminated.

### DIFF
--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -81,13 +81,22 @@ void FAudio_INTERNAL_debug(
 
 	/* The actual message... */
 	va_start(va, fmt);
-	FAudio_vsnprintf(
+	out += FAudio_vsnprintf(
 		out,
 		sizeof(output) - (out - output),
 		fmt,
 		va
 	);
 	va_end(va);
+
+    char* terminator = output + (1024 - 2);
+    if (out < terminator)
+    {
+        terminator = out;
+    }
+
+    *terminator++ = '\n';
+    *terminator++ = '\0';
 
 	/* Print, finally. */
 	FAudio_Log(output);


### PR DESCRIPTION
Prior to this, debug output with no \n results in multiple calls to OutputDebugStringA() on Windows resulting in some very, very long lines in (for example) the Output window in Visual Studio's debugger. In Visual Studio's case, this is enough to degrade UI performance to unusable points.