### PR TITLE
Supporting optional logging to user-provided callback.

### DIFF
--- a/include/FAudio.h
+++ b/include/FAudio.h
@@ -316,6 +316,8 @@ typedef struct FAudioDebugConfiguration
 	int32_t LogFileline;
 	int32_t LogFunctionName;
 	int32_t LogTiming;
+    void (*LogCallback)(const char* msg, void* userData);
+    void* LogUserData;
 } FAudioDebugConfiguration;
 
 #pragma pack(pop)

--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -90,7 +90,14 @@ void FAudio_INTERNAL_debug(
 	va_end(va);
 
 	/* Print, finally. */
-	FAudio_Log(output);
+    if (audio->debug.LogCallback)
+    {
+        audio->debug.LogCallback(output, audio->debug.LogUserData);
+    }
+    else
+    {
+	    FAudio_Log(output);
+    }
 }
 
 static const char *get_wformattag_string(const FAudioWaveFormatEx *fmt)


### PR DESCRIPTION
Some users might want to redirect this, or reconcile it with logging from other subsystems in a single sink.