### PR TITLE
Add FAudioCreateCollector to create a FAPO that captures samples into a buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ add_library(${target}
 	src/FAPOFX_reverb.c
 	src/FAudio.c
 	src/FAudioFX_reverb.c
+	src/FAudioFX_collector.c
 	src/FAudioFX_volumemeter.c
 	src/FAudio_internal.c
 	src/FAudio_internal_simd.c

--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -1071,7 +1071,12 @@ public static class FAudio
 	}
 
 	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-	public static extern uint FAudioCreateCollector(
+	public static extern uint FAudioCollectorGetWritePositionEXT(
+		IntPtr pApo
+	);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern uint FAudioCreateCollectorEXT(
 		out IntPtr ppApo,
 		UInt32 flags,
 		IntPtr pBuffer,

--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -1071,6 +1071,25 @@ public static class FAudio
 	}
 
 	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern uint FAudioCreateCollector(
+		out IntPtr ppApo,
+		UInt32 flags,
+		IntPtr pBuffer,
+		UInt32 bufferLength
+	);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
+	public static extern uint FAudioCreateCollectorWithCustomAllocatorEXT(
+		out IntPtr ppApo,
+		UInt32 flags,
+		IntPtr pBuffer,
+		UInt32 bufferLength,
+		IntPtr customMalloc,
+		IntPtr customFree,
+		IntPtr customRealloc
+	);
+
+	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 	public static extern uint CreateFAPOBase(
 		IntPtr fapo,
 		// The create operation does not copy this into its own persistent storage! This pointer must remain valid.

--- a/csharp/FAudio.cs
+++ b/csharp/FAudio.cs
@@ -1070,10 +1070,10 @@ public static class FAudio
 		IntPtr pRealloc;
 	}
 
-	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
-	public static extern uint FAudioCollectorGetWritePositionEXT(
-		IntPtr pApo
-	);
+	[StructLayout(LayoutKind.Sequential, Pack = 4)]
+	public struct FAudioFXCollectorState {
+		public UInt32 WriteOffset;
+	};
 
 	[DllImport(nativeLibName, CallingConvention = CallingConvention.Cdecl)]
 	public static extern uint FAudioCreateCollectorEXT(

--- a/extensions/CollectorEXT.txt
+++ b/extensions/CollectorEXT.txt
@@ -14,6 +14,10 @@ New Defines
 
 New Types
 ---------
+typedef struct FAudioFXCollectorState
+{
+	uint32_t WriteOffset;
+} FAudioFXCollectorState;
 
 New Procedures and Functions
 ----------------------------
@@ -32,10 +36,6 @@ FAUDIOAPI uint32_t FAudioCreateCollectorWithCustomAllocatorEXT(
 	FAudioMallocFunc customMalloc,
 	FAudioFreeFunc customFree,
 	FAudioReallocFunc customRealloc
-);
-
-FAUDIOAPI uint32_t FAudioCollectorGetWritePositionEXT(
-	FAPO* pApo
 );
 
 How to Use
@@ -59,7 +59,13 @@ FAudio.FAudioEffectChain effectChain = new() {
     pEffectDescriptors = (IntPtr)Unsafe.AsPointer(ref effectDescriptor)
 };
 
+
 FAQ
 ---
 Q. How do I avoid processing the same samples twice, or missing samples, if my game is running faster/slower than the mixer?
-A. Allocate a sufficiently large ring buffer and use FAudioCollectorGetWritePositionEXT to determine the current write position of the mixer, then read the N most recent samples before the write position. The write position is updated once per block of processed samples instead of once per sample so it doesn't change that often.
+A. Allocate a sufficiently large ring buffer and use GetParameters to determine the current write position of the mixer, then read the N most recent samples before the write position. The write position is updated once per block of processed samples instead of once per sample so it doesn't change that often. i.e.
+
+FAudio.FAudioFXCollectorState parameters = default;
+FAudio.FAudioVoice_GetEffectParameters(
+    Voice, 0, (IntPtr)(&parameters), (uint)sizeof(FAudio.FAudioFXCollectorState)
+);

--- a/extensions/CollectorEXT.txt
+++ b/extensions/CollectorEXT.txt
@@ -1,0 +1,65 @@
+CollectorEXT - Allow asynchronously capturing samples via an effect chain
+
+About
+-----
+By default if you want to do sophisticated monitoring of mixed samples in XAudio, you need to author a custom FAPO and insert it into an effect chain. Doing this correctly can be somewhat tricky, and for developers using garbage collected languages this can introduce the potential for a GC pause on the mixer thread (causing audio dropouts).
+This extension introduces a new built-in FAPO called "Collector" that captures samples into a user-provided ring buffer.
+
+Dependencies
+------------
+This extension does not interact with any non-standard XAudio features.
+
+New Defines
+-----------
+
+New Types
+---------
+
+New Procedures and Functions
+----------------------------
+FAUDIOAPI uint32_t FAudioCreateCollectorEXT(
+	FAPO** ppApo, 
+	uint32_t Flags, 
+	float* pBuffer, 
+	uint32_t bufferLength
+);
+
+FAUDIOAPI uint32_t FAudioCreateCollectorWithCustomAllocatorEXT(
+	FAPO** ppApo,
+	uint32_t Flags,
+	float* pBuffer, 
+	uint32_t bufferLength, 
+	FAudioMallocFunc customMalloc,
+	FAudioFreeFunc customFree,
+	FAudioReallocFunc customRealloc
+);
+
+FAUDIOAPI uint32_t FAudioCollectorGetWritePositionEXT(
+	FAPO* pApo
+);
+
+How to Use
+----------
+Allocate a sufficiently large ring buffer and pass it in to FAudioCreateCollectorEXT. Then take the resulting FAPO and add it to an effect chain, i.e.
+
+var buffer = new float[1024];
+var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+
+FAudio.FAudioCreateCollector(
+    out var pCollector,
+    0, handle.AddrOfPinnedObject(), (uint)buffer.Length
+);
+
+FAudio.FAudioEffectDescriptor effectDescriptor = new() {
+    OutputChannels = 2,
+    pEffect = pCollector
+};
+FAudio.FAudioEffectChain effectChain = new() {
+    EffectCount = 1,
+    pEffectDescriptors = (IntPtr)Unsafe.AsPointer(ref effectDescriptor)
+};
+
+FAQ
+---
+Q. How do I avoid processing the same samples twice, or missing samples, if my game is running faster/slower than the mixer?
+A. Allocate a sufficiently large ring buffer and use FAudioCollectorGetWritePositionEXT to determine the current write position of the mixer, then read the N most recent samples before the write position. The write position is updated once per block of processed samples instead of once per sample so it doesn't change that often.

--- a/include/FAudioFX.h
+++ b/include/FAudioFX.h
@@ -262,11 +262,21 @@ typedef struct FAudioFXReverbI3DL2Parameters
 
 /* Functions */
 
+FAUDIOAPI uint32_t FAudioCreateCollector(FAPO** ppApo, uint32_t Flags, float* pBuffer, uint32_t bufferLength);
 FAUDIOAPI uint32_t FAudioCreateVolumeMeter(FAPO** ppApo, uint32_t Flags);
 FAUDIOAPI uint32_t FAudioCreateReverb(FAPO** ppApo, uint32_t Flags);
 FAUDIOAPI uint32_t FAudioCreateReverb9(FAPO** ppApo, uint32_t Flags);
 
 /* See "extensions/CustomAllocatorEXT.txt" for more information. */
+FAUDIOAPI uint32_t FAudioCreateCollectorWithCustomAllocatorEXT(
+	FAPO** ppApo,
+	uint32_t Flags,
+	float* pBuffer, 
+	uint32_t bufferLength, 
+	FAudioMallocFunc customMalloc,
+	FAudioFreeFunc customFree,
+	FAudioReallocFunc customRealloc
+);
 FAUDIOAPI uint32_t FAudioCreateVolumeMeterWithCustomAllocatorEXT(
 	FAPO** ppApo,
 	uint32_t Flags,

--- a/include/FAudioFX.h
+++ b/include/FAudioFX.h
@@ -56,6 +56,11 @@ typedef struct FAudioFXVolumeMeterLevels
 	uint32_t ChannelCount;
 } FAudioFXVolumeMeterLevels;
 
+typedef struct FAudioFXCollectorState
+{
+	uint32_t WriteOffset;
+} FAudioFXCollectorState;
+
 typedef struct FAudioFXReverbParameters
 {
 	float WetDryMix;
@@ -307,10 +312,6 @@ FAUDIOAPI void ReverbConvertI3DL2ToNative9(
 	const FAudioFXReverbI3DL2Parameters *pI3DL2,
 	FAudioFXReverbParameters9 *pNative,
 	int32_t sevenDotOneReverb
-);
-
-FAUDIOAPI uint32_t FAudioCollectorGetWritePositionEXT(
-	FAPO* pApo
 );
 
 #ifdef __cplusplus

--- a/include/FAudioFX.h
+++ b/include/FAudioFX.h
@@ -262,7 +262,7 @@ typedef struct FAudioFXReverbI3DL2Parameters
 
 /* Functions */
 
-FAUDIOAPI uint32_t FAudioCreateCollector(FAPO** ppApo, uint32_t Flags, float* pBuffer, uint32_t bufferLength);
+FAUDIOAPI uint32_t FAudioCreateCollectorEXT(FAPO** ppApo, uint32_t Flags, float* pBuffer, uint32_t bufferLength);
 FAUDIOAPI uint32_t FAudioCreateVolumeMeter(FAPO** ppApo, uint32_t Flags);
 FAUDIOAPI uint32_t FAudioCreateReverb(FAPO** ppApo, uint32_t Flags);
 FAUDIOAPI uint32_t FAudioCreateReverb9(FAPO** ppApo, uint32_t Flags);
@@ -307,6 +307,10 @@ FAUDIOAPI void ReverbConvertI3DL2ToNative9(
 	const FAudioFXReverbI3DL2Parameters *pI3DL2,
 	FAudioFXReverbParameters9 *pNative,
 	int32_t sevenDotOneReverb
+);
+
+FAUDIOAPI uint32_t FAudioCollectorGetWritePositionEXT(
+	FAPO* pApo
 );
 
 #ifdef __cplusplus

--- a/src/FAudioFX_collector.c
+++ b/src/FAudioFX_collector.c
@@ -170,14 +170,17 @@ void FAudioFXCollector_Free(void* fapo)
 	collector->base.pFree(fapo);
 }
 
-/* Public API */
-
-uint32_t FAudioCollectorGetWritePositionEXT(FAPO* pApo)
-{
-	FAudioFXCollector* collector = (FAudioFXCollector*)pApo;
-	SDL_assert(collector);
-	return collector->writeOffset;
+void FAudioFXCollector_GetParameters(
+	FAudioFXCollector* fapo,
+	FAudioFXCollectorState* pParameters,
+	uint32_t ParameterByteSize
+) {
+	FAudio_assert(pParameters);
+	FAudio_assert(ParameterByteSize == sizeof(FAudioFXCollectorState));
+	pParameters->WriteOffset = fapo->writeOffset;
 }
+
+/* Public API */
 
 uint32_t FAudioCreateCollectorEXT(FAPO** ppApo, uint32_t Flags, float* pBuffer, uint32_t bufferLength)
 {
@@ -201,9 +204,9 @@ FAUDIOAPI uint32_t FAudioCreateCollectorWithCustomAllocatorEXT(
 	FAudioFreeFunc customFree,
 	FAudioReallocFunc customRealloc
 ) {
-	SDL_assert(ppApo);
-	SDL_assert(pBuffer);
-	SDL_assert(bufferLength);
+	FAudio_assert(ppApo);
+	FAudio_assert(pBuffer);
+	FAudio_assert(bufferLength);
 
 	/* Allocate... */
 	FAudioFXCollector *result = (FAudioFXCollector*) customMalloc(
@@ -234,7 +237,8 @@ FAUDIOAPI uint32_t FAudioCreateCollectorWithCustomAllocatorEXT(
 		FAudioFXCollector_UnlockForProcess;
 	result->base.base.Process = (ProcessFunc)
 		FAudioFXCollector_Process;
-	result->base.base.GetParameters = NULL;
+	result->base.base.GetParameters = (GetParametersFunc)
+		FAudioFXCollector_GetParameters;
 	result->base.Destructor = FAudioFXCollector_Free;
 
 	result->pBuffer = pBuffer;

--- a/src/FAudioFX_collector.c
+++ b/src/FAudioFX_collector.c
@@ -1,0 +1,243 @@
+/* FAudio - XAudio Reimplementation for FNA
+ *
+ * Copyright (c) 2011-2025 Ethan Lee and the FNA team
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software in a
+ * product, an acknowledgment in the product documentation would be
+ * appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ *
+ * Katelyn Gadd <kg@luminance.org>
+ *
+ */
+
+#include "FAudioFX.h"
+#include "FAudio_internal.h"
+#include "SDL_atomic.h"
+
+/* Sample Collector FAPO Implementation */
+
+const FAudioGUID FAudioFX_CLSID_Collector = /* 2.7 */
+{
+	0xCAC1105F,
+	0x619B,
+	0x4D04,
+	{
+		0x83,
+		0x1A,
+		0x44,
+		0xE1,
+		0xCB,
+		0xF1,
+		0x2D,
+		0x58
+	}
+};
+
+static FAPORegistrationProperties CollectorProperties =
+{
+	/* .clsid = */ {0},
+	/* .FriendlyName = */
+	{
+		'C', 'o', 'l', 'l', 'e', 'c', 't', 'o', 'r', '\0'
+	},
+	/*.CopyrightInfo = */
+	{
+		'C', 'o', 'p', 'y', 'r', 'i', 'g', 'h', 't', ' ', '(', 'c', ')',
+		'K', 'a', 't', 'e', 'l', 'y', 'n', ' ', 'G', 'a', 'd', 'd', '\0'
+	},
+	/*.MajorVersion = */ 0,
+	/*.MinorVersion = */ 0,
+	/*.Flags = */(
+		FAPO_FLAG_CHANNELS_MUST_MATCH |
+		FAPO_FLAG_FRAMERATE_MUST_MATCH |
+		FAPO_FLAG_BITSPERSAMPLE_MUST_MATCH |
+		FAPO_FLAG_BUFFERCOUNT_MUST_MATCH |
+		FAPO_FLAG_INPLACE_SUPPORTED |
+		FAPO_FLAG_INPLACE_REQUIRED
+	),
+	/*.MinInputBufferCount = */ 1,
+	/*.MaxInputBufferCount = */ 1,
+	/*.MinOutputBufferCount = */ 1,
+	/*.MaxOutputBufferCount =*/ 1
+};
+
+typedef struct FAudioFXCollector
+{
+	FAPOBase base;
+	uint16_t channels;
+	float*   pBuffer;
+	uint32_t bufferLength;
+	uint32_t writeOffset;
+} FAudioFXCollector;
+
+uint32_t FAudioFXCollector_LockForProcess(
+	FAudioFXCollector*fapo,
+	uint32_t InputLockedParameterCount,
+	const FAPOLockForProcessBufferParameters *pInputLockedParameters,
+	uint32_t OutputLockedParameterCount,
+	const FAPOLockForProcessBufferParameters *pOutputLockedParameters
+) {
+	/* Verify parameter counts... */
+	if (	InputLockedParameterCount < fapo->base.m_pRegistrationProperties->MinInputBufferCount ||
+		InputLockedParameterCount > fapo->base.m_pRegistrationProperties->MaxInputBufferCount ||
+		OutputLockedParameterCount < fapo->base.m_pRegistrationProperties->MinOutputBufferCount ||
+		OutputLockedParameterCount > fapo->base.m_pRegistrationProperties->MaxOutputBufferCount	)
+	{
+		return FAUDIO_E_INVALID_ARG;
+	}
+
+
+	/* Validate input/output formats */
+	#define VERIFY_FORMAT_FLAG(flag, prop) \
+		if (	(fapo->base.m_pRegistrationProperties->Flags & flag) && \
+			(pInputLockedParameters->pFormat->prop != pOutputLockedParameters->pFormat->prop)	) \
+		{ \
+			return FAUDIO_E_INVALID_ARG; \
+		}
+	VERIFY_FORMAT_FLAG(FAPO_FLAG_CHANNELS_MUST_MATCH, nChannels)
+	VERIFY_FORMAT_FLAG(FAPO_FLAG_FRAMERATE_MUST_MATCH, nSamplesPerSec)
+	VERIFY_FORMAT_FLAG(FAPO_FLAG_BITSPERSAMPLE_MUST_MATCH, wBitsPerSample)
+	#undef VERIFY_FORMAT_FLAG
+	if (	(fapo->base.m_pRegistrationProperties->Flags & FAPO_FLAG_BUFFERCOUNT_MUST_MATCH) &&
+		(InputLockedParameterCount != OutputLockedParameterCount)	)
+	{
+		return FAUDIO_E_INVALID_ARG;
+	}
+
+	fapo->channels = pInputLockedParameters->pFormat->nChannels;
+	fapo->base.m_fIsLocked = 1;
+	return 0;
+}
+
+void FAudioFXCollector_UnlockForProcess(FAudioFXCollector*fapo)
+{
+	fapo->base.m_fIsLocked = 0;
+}
+
+void FAudioFXCollector_Process(
+	FAudioFXCollector* fapo,
+	uint32_t InputProcessParameterCount,
+	const FAPOProcessBufferParameters* pInputProcessParameters,
+	uint32_t OutputProcessParameterCount,
+	FAPOProcessBufferParameters* pOutputProcessParameters,
+	int32_t IsEnabled
+) {
+	uint32_t channels = fapo->channels,
+		bufferLength = fapo->bufferLength,
+		sampleCount = pInputProcessParameters->ValidFrameCount;
+	uint32_t writeOffset = fapo->writeOffset;
+	float* pBuffer = (float*)pInputProcessParameters->pBuffer;
+	float* pOutput = fapo->pBuffer;
+	float multiplier = 1.0f / channels;
+
+	for (uint32_t i = 0; i < sampleCount; i++) {
+		// Accumulate all channels and average them
+		float accumulator = 0;
+		for (uint32_t j = 0; j < channels; j++)
+			accumulator += pBuffer[j];
+		accumulator *= multiplier;
+
+		// Advance to next set of samples
+		pBuffer += channels;
+
+		// Write to output buffer
+		pOutput[writeOffset++] = accumulator;
+		// Wrap write offset
+		if (writeOffset >= bufferLength)
+			writeOffset = 0;
+	}
+
+	fapo->writeOffset = writeOffset;
+	FAPOBase_EndProcess(&fapo->base);
+}
+
+void FAudioFXCollector_Free(void* fapo)
+{
+	FAudioFXCollector *collector = (FAudioFXCollector*) fapo;
+	collector->base.pFree(fapo);
+}
+
+/* Public API */
+
+uint32_t FAudioCreateCollector(FAPO** ppApo, uint32_t Flags, float* pBuffer, uint32_t bufferLength)
+{
+	return FAudioCreateCollectorWithCustomAllocatorEXT(
+		ppApo,
+		Flags,
+		pBuffer,
+		bufferLength,
+		FAudio_malloc,
+		FAudio_free,
+		FAudio_realloc
+	);
+}
+
+FAUDIOAPI uint32_t FAudioCreateCollectorWithCustomAllocatorEXT(
+	FAPO** ppApo,
+	uint32_t Flags,
+	float* pBuffer,
+	uint32_t bufferLength,
+	FAudioMallocFunc customMalloc,
+	FAudioFreeFunc customFree,
+	FAudioReallocFunc customRealloc
+) {
+	SDL_assert(ppApo);
+	SDL_assert(pBuffer);
+	SDL_assert(bufferLength);
+
+	/* Allocate... */
+	FAudioFXCollector *result = (FAudioFXCollector*) customMalloc(
+		sizeof(FAudioFXCollector)
+	);
+
+	/* Initialize... */
+	FAudio_memcpy(
+		&CollectorProperties.clsid,
+		&FAudioFX_CLSID_Collector,
+		sizeof(FAudioGUID)
+	);
+	CreateFAPOBaseWithCustomAllocatorEXT(
+		&result->base,
+		&CollectorProperties,
+		NULL,
+		0,
+		1,
+		customMalloc,
+		customFree,
+		customRealloc
+	);
+
+	/* Function table... */
+	result->base.base.LockForProcess = (LockForProcessFunc)
+		FAudioFXCollector_LockForProcess;
+	result->base.base.UnlockForProcess = (UnlockForProcessFunc)
+		FAudioFXCollector_UnlockForProcess;
+	result->base.base.Process = (ProcessFunc)
+		FAudioFXCollector_Process;
+	result->base.base.GetParameters = NULL;
+	result->base.Destructor = FAudioFXCollector_Free;
+
+	result->pBuffer = pBuffer;
+	result->writeOffset = 0;
+	result->bufferLength = bufferLength;
+
+	/* Finally. */
+	*ppApo = &result->base.base;
+	return 0;
+}
+
+/* vim: set noexpandtab shiftwidth=8 tabstop=8: */

--- a/src/FAudioFX_collector.c
+++ b/src/FAudioFX_collector.c
@@ -123,7 +123,7 @@ uint32_t FAudioFXCollector_LockForProcess(
 	return 0;
 }
 
-void FAudioFXCollector_UnlockForProcess(FAudioFXCollector*fapo)
+void FAudioFXCollector_UnlockForProcess(FAudioFXCollector* fapo)
 {
 	fapo->base.m_fIsLocked = 0;
 }
@@ -173,7 +173,14 @@ void FAudioFXCollector_Free(void* fapo)
 
 /* Public API */
 
-uint32_t FAudioCreateCollector(FAPO** ppApo, uint32_t Flags, float* pBuffer, uint32_t bufferLength)
+uint32_t FAudioCollectorGetWritePositionEXT(FAPO* pApo)
+{
+	FAudioFXCollector* collector = (FAudioFXCollector*)pApo;
+	SDL_assert(collector);
+	return collector->writeOffset;
+}
+
+uint32_t FAudioCreateCollectorEXT(FAPO** ppApo, uint32_t Flags, float* pBuffer, uint32_t bufferLength)
 {
 	return FAudioCreateCollectorWithCustomAllocatorEXT(
 		ppApo,

--- a/src/FAudioFX_collector.c
+++ b/src/FAudioFX_collector.c
@@ -26,7 +26,6 @@
 
 #include "FAudioFX.h"
 #include "FAudio_internal.h"
-#include "SDL_atomic.h"
 
 /* Sample Collector FAPO Implementation */
 

--- a/visualc-gdk/FAudio.vcxproj
+++ b/visualc-gdk/FAudio.vcxproj
@@ -52,6 +52,7 @@
     <ClCompile Include="..\src\FAPOFX_masteringlimiter.c" />
     <ClCompile Include="..\src\FAPOFX_reverb.c" />
     <ClCompile Include="..\src\FAudio.c" />
+    <ClCompile Include="..\src\FAudioFX_collector.c" />
     <ClCompile Include="..\src\FAudioFX_reverb.c" />
     <ClCompile Include="..\src\FAudioFX_volumemeter.c" />
     <ClCompile Include="..\src\FAudio_internal.c" />

--- a/visualc/FAudio.vcxproj
+++ b/visualc/FAudio.vcxproj
@@ -73,6 +73,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\F3DAudio.c" />
     <ClCompile Include="..\src\FAudio.c" />
+    <ClCompile Include="..\src\FAudioFX_collector.c" />
     <ClCompile Include="..\src\FAudio_internal.c" />
     <ClCompile Include="..\src\FAudio_internal_simd.c" />
     <ClCompile Include="..\src\FAudio_operationset.c" />


### PR DESCRIPTION
Simple and easy to use. Hand it a ring buffer and it will fill it with mono samples (so you don't need to think about how many channels there are), and you can feed that into an FFT or something else in order to do a realtime spectrum analyzer, etc.

I previously did this with a custom callback from outside but Collector makes it much easier and eliminates the possibility of crashing/hanging the mixer thread.