### PR TITLE
build: fix warnings for MSVC

### DIFF
--- a/src/FAudio_platform_sdl3.c
+++ b/src/FAudio_platform_sdl3.c
@@ -61,9 +61,9 @@ static void FAudio_INTERNAL_MixCallback(
 		SDL_PutAudioStreamData(
 			stream,
 			dev->stagingBuffer,
-			dev->stagingLen
+			(int)dev->stagingLen
 		);
-		additional_amount -= dev->stagingLen;
+		additional_amount -= (int)dev->stagingLen;
 	}
 }
 
@@ -265,7 +265,7 @@ uint32_t FAudio_PlatformGetDeviceDetails(
 	FAudio_zero(details, sizeof(FAudioDeviceDetails));
 
 	devs = SDL_GetAudioPlaybackDevices(&devcount);
-	if (index > devcount)
+	if ((int)index > devcount)
 	{
 		SDL_free(devs);
 		return FAUDIO_E_INVALID_CALL;
@@ -424,7 +424,7 @@ void FAudio_sleep(uint32_t ms)
 
 uint32_t FAudio_timems()
 {
-	return SDL_GetTicks();
+	return (uint32_t)SDL_GetTicks();
 }
 
 /* FAudio I/O */

--- a/src/FAudio_platform_win32_wmadec.c
+++ b/src/FAudio_platform_win32_wmadec.c
@@ -41,7 +41,7 @@ static HRESULT FAudio_WMAMF_ProcessInput(
 	BYTE *copy_buf;
 	HRESULT hr;
 
-	copy_size = min(buffer->AudioBytes - impl->input_pos, impl->input_size);
+	copy_size = (DWORD)min(buffer->AudioBytes - impl->input_pos, impl->input_size);
 	if (!copy_size) return S_FALSE;
 	LOG_INFO(voice->audio, "pushing %x bytes at %x", copy_size, impl->input_pos);
 


### PR DESCRIPTION
Fix some warnings for MSVC. Mostly by type casts. Convert one `fopen()` call to `fopen_s()` with error handling and one double -> int conversion for a buffer size with `ceil()`.