### PR TITLE
win32: Use AUTOCONVERTPCM when initializing the audio client.

### DIFF
--- a/src/FAudio_platform_win32.c
+++ b/src/FAudio_platform_win32.c
@@ -352,7 +352,6 @@ void FAudio_PlatformInit(
 	struct FAudioAudioClientThreadArgs *args;
 	struct FAudioWin32PlatformData *data;
 	REFERENCE_TIME duration;
-	WAVEFORMATEX *closest;
 	IMMDevice *device = NULL;
 	HRESULT hr;
 	HANDLE audioEvent = NULL;
@@ -419,25 +418,10 @@ void FAudio_PlatformInit(
 	if (flags & FAUDIO_1024_QUANTUM) duration = 213333;
 	else duration = 100000;
 
-	hr = IAudioClient_IsFormatSupported(
-		data->client,
-		AUDCLNT_SHAREMODE_SHARED,
-		&args->format.Format,
-		&closest
-	);
-	FAudio_assert(!FAILED(hr) && "Failed to find supported audio format!");
-
-	if (closest)
-	{
-		if (closest->wFormatTag != WAVE_FORMAT_EXTENSIBLE) args->format.Format = *closest;
-		else args->format = *(WAVEFORMATEXTENSIBLE *)closest;
-		CoTaskMemFree(closest);
-	}
-
 	hr = IAudioClient_Initialize(
 		data->client,
 		AUDCLNT_SHAREMODE_SHARED,
-		AUDCLNT_STREAMFLAGS_EVENTCALLBACK,
+		AUDCLNT_STREAMFLAGS_EVENTCALLBACK | AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM,
 		duration * 3,
 		0,
 		&args->format.Format,


### PR DESCRIPTION
I didn't manage to compile FAudio with the win32 backend. I tested this patch with a few games by cherry picking it in Proton and everything seemed to work just as before.

See the commit message for some explanation. Currently Wine has the same behavior independently of whether `AUTOCONVERTPCM` is set, but on Windows calling `Initialize()` without `AUTOCONVERTPCM` will be rejected unless the requested format is similar enough to the mix format. I plan to submit a MR that aligns Wine with Windows, so if you want to preserve the current behavior for FAudio flag `AUTOCONVERTPCM` should be passed instead.