### PR TITLE
Set default 7.1 channel mask to SDL3 and Windows defaults

### DIFF
--- a/src/FAudio_internal.h
+++ b/src/FAudio_internal.h
@@ -835,7 +835,7 @@ static inline uint32_t GetMask(uint16_t channels)
 	if (channels == 4) return SPEAKER_QUAD;
 	if (channels == 5) return SPEAKER_4POINT1;
 	if (channels == 6) return SPEAKER_5POINT1;
-	if (channels == 8) return SPEAKER_7POINT1;
+	if (channels == 8) return SPEAKER_7POINT1_SURROUND;
 	FAudio_assert(0 && "Unrecognized speaker layout!");
 	return 0;
 }


### PR DESCRIPTION
https://wiki.libsdl.org/SDL3/CategoryAudio#channel-layouts:
  8 channels (7.1) layout: FL, FR, FC, LFE, BL, BR, SL, SR

https://learn.microsoft.com/en-us/windows-hardware/drivers/audio/header-file-changes:

  KSAUDIO_SPEAKER_7POINT1_SURROUND FL, FR, FC, LFE, BL, BR, SL, SR

  In Windows Vista and later versions of Windows, the
  KSAUDIO_SPEAKER_7POINT1 speaker configuration is no longer supported

