### PR TITLE
Fixed a memory leak (individual voice effects.parameters)

### DIFF
--- a/src/FAudio_internal.c
+++ b/src/FAudio_internal.c
@@ -1700,6 +1700,7 @@ void FAudio_INTERNAL_FreeEffectChain(FAudioVoice *voice)
 	{
 		voice->effects.desc[i].pEffect->UnlockForProcess(voice->effects.desc[i].pEffect);
 		voice->effects.desc[i].pEffect->Release(voice->effects.desc[i].pEffect);
+		voice->audio->pFree(voice->effects.parameters[i]);
 	}
 
 	voice->audio->pFree(voice->effects.desc);


### PR DESCRIPTION
Fixed a memory leak. Code would release the parameter array, but not individual elements (allocated in FAudioVoice_SetEffectParameters)