### PR TITLE
faudio: Don't fixup wma bitrate if it's already valid.

### DIFF
--- a/src/FAudio.c
+++ b/src/FAudio.c
@@ -337,7 +337,7 @@ static uint32_t fixup_wma_bitrate(FAudio *audio, const FAudioWaveFormatEx *forma
 
 			for (unsigned int j = 0; j < 5 && rates[i].bytes_per_second[j]; ++j)
 			{
-				if (format->nAvgBytesPerSec > rates[i].bytes_per_second[j])
+				if (format->nAvgBytesPerSec >= rates[i].bytes_per_second[j])
 					ret = rates[i].bytes_per_second[j];
 			}
 


### PR DESCRIPTION
Fixes music in Gridrunner Revolution and other games, cf. https://bugs.winehq.org/show_bug.cgi?id=59841.

Fixes: 5df7ccfb8a12746f9abf6c83b1e2fb1f3f1b8f11