### PR TITLE
Create the WMA decoder without using COM

### DIFF
--- a/src/FAudio_platform_win32_wmadec.c
+++ b/src/FAudio_platform_win32_wmadec.c
@@ -247,6 +247,34 @@ error:
 	LOG_FUNC_EXIT(voice->audio)
 }
 
+static HRESULT create_wma_decoder(IMFTransform **out)
+{
+	static HRESULT (WINAPI *pDllGetClassObject)(REFCLSID, REFIID, void **);
+	IClassFactory *factory;
+	HMODULE wmadmod;
+	HRESULT hr;
+
+	if (!pDllGetClassObject)
+	{
+		if (!(wmadmod = LoadLibraryW(L"wmadmod.dll")))
+			return E_FAIL;
+
+		pDllGetClassObject = (HRESULT (WINAPI *)(REFCLSID, REFIID, void **)) GetProcAddress(wmadmod, "DllGetClassObject");
+
+		if (!pDllGetClassObject)
+			return E_FAIL;
+	}
+
+	hr = pDllGetClassObject(&CLSID_CWMADecMediaObject, &IID_IClassFactory, (void **)&factory);
+	if (FAILED(hr))
+		return hr;
+
+	hr = IClassFactory_CreateInstance(factory, NULL, &IID_IMFTransform, (void **)out);
+	IClassFactory_Release(factory);
+
+	return hr;
+}
+
 uint32_t FAudio_WMADEC_init(FAudioSourceVoice *voice, uint32_t type)
 {
 	static const uint8_t fake_codec_data[16] = {0, 0, 0, 0, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -266,13 +294,7 @@ uint32_t FAudio_WMADEC_init(FAudioSourceVoice *voice, uint32_t type)
 	if (!(impl = voice->audio->pMalloc(sizeof(*impl)))) return -1;
 	FAudio_memset(impl, 0, sizeof(*impl));
 
-	hr = CoCreateInstance(
-		&CLSID_CWMADecMediaObject,
-		0,
-		CLSCTX_INPROC_SERVER,
-		&IID_IMFTransform,
-		(void **)&decoder
-	);
+	hr = create_wma_decoder(&decoder);
 	if (FAILED(hr))
 	{
 		voice->audio->pFree(impl->output_buf);


### PR DESCRIPTION
- [x] I confirm that I am the author of this code and release it to the FNA project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

Follow-up to an issue found with upstream Wine in STEINS;GATE REBOOT, which was not playing the characters voiceovers: https://gitlab.winehq.org/wine/wine/-/merge_requests/11717

Every time a voice was supposed to play, the following showed up in Wine logs: `err:ole:com_get_class_object apartment not initialised` and tracing this led to FAudio_WMADEC_init() and its CoCreateInstance() used to create the decoder.

This happens because the game destroys the COM apartment it previously initialized for audio before creating the WMA voices, which is harmless on Windows where xaudio2 decodes xWMA without COM, so an application is free to have no apartment at that point.

After discussing the issue with maintainers in the MR, the proposed solution was to reach the decoder without using COM at all, relying on wmadmod instead. Its class factory is available through DllGetClassObject(), which needs no apartment and works the same on Windows and under Wine.

Tested on Windows 10 as well, where FAudio fails the same way while native xaudio2 creates and plays the voice fine with no apartment at all.